### PR TITLE
fix(send): remove chain param from sendTransaction to fix Sepolia 

### DIFF
--- a/SPECTER-web/src/lib/blockchain/errorParser.ts
+++ b/SPECTER-web/src/lib/blockchain/errorParser.ts
@@ -69,6 +69,34 @@ export function parseBlockchainError(error: unknown): ParsedError {
     };
   }
 
+  // JSON-RPC protocol version error (Dynamic Labs / WalletConnect provider quirk)
+  if (
+    err?.message?.includes('Version of JSON-RPC protocol is not supported') ||
+    err?.message?.includes('JSON-RPC protocol') ||
+    (err?.code === -32600 && err?.message)
+  ) {
+    return {
+      title: 'Wallet provider error',
+      message: 'Your wallet returned a JSON-RPC compatibility error. Try switching networks manually in your wallet and retry, or reconnect your wallet.',
+      isUserAction: true,
+    };
+  }
+
+  // Gas fee cap error (stale estimate, common on Arbitrum Sepolia)
+  if (
+    err?.message?.includes('fee cap') ||
+    err?.message?.includes('maxFeePerGas') ||
+    err?.message?.includes('block base fee') ||
+    err?.message?.includes('FeeTooLow') ||
+    err?.message?.includes('gas price too low')
+  ) {
+    return {
+      title: 'Gas fee too low',
+      message: 'The gas fee estimate was lower than the current network base fee. Please retry — the wallet will re-estimate with current fees.',
+      isUserAction: true,
+    };
+  }
+
   // RPC/Network errors
   if (
     err?.message?.includes('could not detect network') ||

--- a/SPECTER-web/src/pages/SendPayment.tsx
+++ b/SPECTER-web/src/pages/SendPayment.tsx
@@ -1123,11 +1123,16 @@ export default function SendPayment() {
           setPublishPhase("idle");
           return;
         }
+        // Do NOT pass `chain` here — we already switched chains above, and
+        // passing `chain` causes viem to re-validate via the wallet's EIP-1193
+        // provider. Some providers (Dynamic Labs / WalletConnect) return a
+        // "JSON-RPC protocol version not supported" error during that step for
+        // standard testnets (Sepolia, Arbitrum Sepolia). Omitting `chain` also
+        // lets the wallet estimate gas natively, avoiding stale maxFeePerGas
+        // rejections on Arbitrum Sepolia.
         txHashResult = await walletClient.sendTransaction({
           to: stealthResult.stealth_address as `0x${string}`,
           value: parseEther(amt),
-          account: walletClient.account,
-          chain: targetChain,
         } as unknown as Parameters<typeof walletClient.sendTransaction>[0]);
         analytics.sendTxSubmitted(evmChain);
         broadcasted = true;


### PR DESCRIPTION

Passing `chain` to viem's sendTransaction triggered internal chain validation through the wallet's EIP-1193 provider. Dynamic Labs / WalletConnect providers return "Version of JSON-RPC protocol is not supported" during that step for standard testnets (Sepolia, Arb Sepolia), while Monad (a defineChain custom chain) was unaffected.

Removing `chain` (and `account`) lets the wallet handle gas estimation natively, also fixing the stale maxFeePerGas rejection on Arbitrum Sepolia. The manual chain switch already performed above makes the param redundant.

Also adds errorParser cases for JSON-RPC version errors and fee-cap errors so users see actionable messages instead of raw RPC error strings.