### PR TITLE
feat(sui): separate USE_SUI_TESTNET flag + move payment details 

### DIFF
--- a/SPECTER-web/src/components/features/wallet/SuiWalletProvider.tsx
+++ b/SPECTER-web/src/components/features/wallet/SuiWalletProvider.tsx
@@ -1,6 +1,6 @@
 import { SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
 import { getJsonRpcFullnodeUrl } from '@mysten/sui/jsonRpc';
-import { sendUseTestnet, useTestnet } from '@/lib/blockchain/chainConfig';
+import { useSuiTestnet } from '@/lib/blockchain/chainConfig';
 import '@mysten/dapp-kit/dist/index.css';
 
 const networks = {
@@ -8,7 +8,7 @@ const networks = {
   testnet: { url: getJsonRpcFullnodeUrl('testnet') },
 };
 
-const defaultNetwork = useTestnet || sendUseTestnet ? 'testnet' : 'mainnet';
+const defaultNetwork = useSuiTestnet ? 'testnet' : 'mainnet';
 
 export function SuiWalletProvider({ children }: { children: React.ReactNode }) {
   return (

--- a/SPECTER-web/src/components/ui/specialized/ticket-confirmation-card.tsx
+++ b/SPECTER-web/src/components/ui/specialized/ticket-confirmation-card.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { CheckCircle2 } from "lucide-react";
+import { CheckCircle2, ExternalLink } from "lucide-react";
 import { cn, formatCryptoAmount } from "@/lib/utils";
 
 // --- Helper Components ---
@@ -125,6 +125,20 @@ export interface TicketProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Currency for amount display (default "USD"). Use "ETH" or "SUI" for crypto (shows icon). */
   currency?: string;
   icon?: React.ReactNode;
+  /** Network + chain label, e.g. "Sui Testnet" or "Sepolia". */
+  chainLabel?: string;
+  /** Full payment ID (shown truncated). */
+  paymentId?: string;
+  /** Announcement registry ID. */
+  announcementId?: string | number;
+  /** Source-chain transaction hash. */
+  txHash?: string;
+  /** Explorer URL for txHash — renders as a hyperlink. */
+  txUrl?: string;
+  /** Monad announce() transaction hash. */
+  monadTxHash?: string;
+  /** Explorer URL for monadTxHash. */
+  monadTxUrl?: string;
 }
 
 const AnimatedTicket = React.forwardRef<HTMLDivElement, TicketProps>(
@@ -138,6 +152,13 @@ const AnimatedTicket = React.forwardRef<HTMLDivElement, TicketProps>(
       last4Digits,
       barcodeValue,
       currency = "USD",
+      chainLabel,
+      paymentId,
+      announcementId,
+      txHash,
+      txUrl,
+      monadTxHash,
+      monadTxUrl,
       ...props
     },
     ref
@@ -232,6 +253,82 @@ const AnimatedTicket = React.forwardRef<HTMLDivElement, TicketProps>(
             <DashedLine />
 
             <Barcode value={barcodeValue} />
+
+            {/* Payment details — only rendered when at least one field is provided */}
+            {(chainLabel || paymentId || announcementId != null || txHash || monadTxHash) && (
+              <>
+                <DashedLine />
+                <div className="space-y-2 text-left">
+                  <p className="text-[10px] font-bold tracking-[0.15em] uppercase text-muted-foreground">
+                    Transaction Details
+                  </p>
+                  <dl className="space-y-1.5">
+                    {chainLabel && (
+                      <div className="flex items-center justify-between gap-2">
+                        <dt className="text-xs text-muted-foreground shrink-0">Network</dt>
+                        <dd className="text-xs font-medium font-mono truncate text-right">{chainLabel}</dd>
+                      </div>
+                    )}
+                    {announcementId != null && (
+                      <div className="flex items-center justify-between gap-2">
+                        <dt className="text-xs text-muted-foreground shrink-0">Announcement</dt>
+                        <dd className="text-xs font-mono text-right">#{announcementId}</dd>
+                      </div>
+                    )}
+                    {paymentId && (
+                      <div className="flex items-center justify-between gap-2">
+                        <dt className="text-xs text-muted-foreground shrink-0">Payment ID</dt>
+                        <dd className="text-xs font-mono text-right truncate max-w-[160px]" title={paymentId}>
+                          {paymentId.slice(0, 8)}…{paymentId.slice(-6)}
+                        </dd>
+                      </div>
+                    )}
+                    {txHash && (
+                      <div className="flex items-center justify-between gap-2">
+                        <dt className="text-xs text-muted-foreground shrink-0">Tx</dt>
+                        <dd className="text-xs font-mono text-right flex items-center gap-1 min-w-0">
+                          <span className="truncate" title={txHash}>
+                            {txHash.slice(0, 10)}…{txHash.slice(-6)}
+                          </span>
+                          {txUrl && (
+                            <a
+                              href={txUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="shrink-0 text-primary/60 hover:text-primary transition-colors"
+                              aria-label="View transaction in explorer"
+                            >
+                              <ExternalLink className="h-3 w-3" />
+                            </a>
+                          )}
+                        </dd>
+                      </div>
+                    )}
+                    {monadTxHash && (
+                      <div className="flex items-center justify-between gap-2">
+                        <dt className="text-xs text-muted-foreground shrink-0">Monad announce</dt>
+                        <dd className="text-xs font-mono text-right flex items-center gap-1 min-w-0">
+                          <span className="truncate" title={monadTxHash}>
+                            {monadTxHash.slice(0, 10)}…{monadTxHash.slice(-6)}
+                          </span>
+                          {monadTxUrl && (
+                            <a
+                              href={monadTxUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="shrink-0 text-primary/60 hover:text-primary transition-colors"
+                              aria-label="View Monad announcement in explorer"
+                            >
+                              <ExternalLink className="h-3 w-3" />
+                            </a>
+                          )}
+                        </dd>
+                      </div>
+                    )}
+                  </dl>
+                </div>
+              </>
+            )}
           </div>
         </div>
       </>

--- a/SPECTER-web/src/lib/api.ts
+++ b/SPECTER-web/src/lib/api.ts
@@ -127,8 +127,10 @@ export interface HealthResponse {
   version: string;
   uptime_seconds: number;
   announcements_count: number;
-  /** When true, backend uses testnet for SuiNS (ENS is always mainnet) */
+  /** General EVM/Monad testnet flag. */
   use_testnet?: boolean;
+  /** When true, backend resolves SuiNS against testnet registry (ENS is always mainnet). */
+  use_sui_testnet?: boolean;
 }
 
 export interface GenerateKeysResponse {

--- a/SPECTER-web/src/lib/blockchain/chainConfig.ts
+++ b/SPECTER-web/src/lib/blockchain/chainConfig.ts
@@ -4,6 +4,8 @@
  * `VITE_USE_TESTNET` — ENS, viem reads, setup (Generate Keys).
  * `VITE_SEND_USE_TESTNET` — send-payment chain picker (Sepolia, Arb Sepolia, Monad, Sui testnet).
  *   Set `true` while testing sends against mainnet ENS; set `false` when going full mainnet.
+ * `VITE_USE_SUI_TESTNET` — SuiNS resolution network, independent of EVM testnet flag.
+ *   Defaults to `VITE_USE_TESTNET` when not set.
  */
 
 import { mainnet, sepolia } from 'viem/chains';
@@ -20,6 +22,16 @@ export const sendUseTestnet =
     : useTestnet ||
       import.meta.env.VITE_SEND_USE_TESTNET === 'true' ||
       import.meta.env.VITE_SEND_USE_TESTNET === '1';
+
+/** Controls which SuiNS network the Sui wallet and resolver use. Independent of EVM testnet. */
+export const useSuiTestnet =
+  import.meta.env.VITE_USE_SUI_TESTNET === 'false' ||
+  import.meta.env.VITE_USE_SUI_TESTNET === '0'
+    ? false
+    : import.meta.env.VITE_USE_SUI_TESTNET === 'true' ||
+      import.meta.env.VITE_USE_SUI_TESTNET === '1'
+      ? true
+      : useTestnet; // fall back to VITE_USE_TESTNET when not explicitly set
 
 export const chainId = useTestnet ? sepolia.id : mainnet.id;
 export const chain = useTestnet ? sepolia : mainnet;

--- a/SPECTER-web/src/lib/blockchain/sendChains.ts
+++ b/SPECTER-web/src/lib/blockchain/sendChains.ts
@@ -1,6 +1,6 @@
 import { createPublicClient, defineChain, fallback, http, type Chain, type PublicClient } from "viem";
 import { arbitrumSepolia, mainnet, sepolia } from "viem/chains";
-import { sendUseTestnet } from "./chainConfig";
+import { sendUseTestnet, useSuiTestnet } from "./chainConfig";
 import {
   CHAIN_STANDARDS,
   EIP155_CHAIN_IDS,
@@ -101,8 +101,8 @@ const EVM_CONFIG: Record<EvmTxChain, {
 
 const SUI_CONFIG: SendChainConfig = {
   id: "sui",
-  label: CHAIN_STANDARDS.sui.label,
-  shortLabel: CHAIN_STANDARDS.sui.shortLabel,
+  label: useSuiTestnet ? "Sui Testnet" : "Sui Mainnet",
+  shortLabel: useSuiTestnet ? "Sui Testnet" : "Sui",
   currencySymbol: CHAIN_STANDARDS.sui.currencySymbol,
   isEvm: false,
   colorClass: "text-[#4DA2FF]",
@@ -154,7 +154,7 @@ export function getRpcUrlForEvm(chain: EvmTxChain): string {
 export function getExplorerTxUrl(chain: TxChain, txHash: string): string {
   if (!txHash) return "";
   if (chain === "sui") {
-    const base = sendUseTestnet ? "https://suiscan.xyz/testnet/tx/" : "https://suiscan.xyz/mainnet/tx/";
+    const base = useSuiTestnet ? "https://suiscan.xyz/testnet/tx/" : "https://suiscan.xyz/mainnet/tx/";
     return `${base}${txHash}`;
   }
   const explorer = EVM_CONFIG[chain].chain.blockExplorers?.default?.url ?? "";

--- a/SPECTER-web/src/pages/GenerateKeys.tsx
+++ b/SPECTER-web/src/pages/GenerateKeys.tsx
@@ -5,7 +5,7 @@ import { isEthereumWallet } from "@dynamic-labs/ethereum";
 import { useQuery } from "@tanstack/react-query";
 import { getEnsNameForAddress } from "@/lib/blockchain/ensLookup";
 import { ENS_APP_URL, ENS_CHAIN_ID, ensAppProfileUrl, ensPublicClient } from "@/lib/blockchain/ensConfig";
-import { useTestnet } from "@/lib/blockchain/chainConfig";
+import { useSuiTestnet } from "@/lib/blockchain/chainConfig";
 import { setEnsTextRecord } from "@/lib/blockchain/ensSetText";
 import { setSuinsContentHash } from "@/lib/blockchain/suinsSetContent";
 import { parseBlockchainError, formatErrorMessage } from "@/lib/blockchain/errorParser";
@@ -13,6 +13,7 @@ import {
   useCurrentAccount,
   useDisconnectWallet,
   useSuiClient,
+  useSuiClientContext,
   useSignAndExecuteTransaction,
   ConnectModal,
 } from "@mysten/dapp-kit";
@@ -407,11 +408,12 @@ export default function GenerateKeys() {
   // Sui wallet (dapp-kit)
   const suiAccount = useCurrentAccount();
   const suiClient = useSuiClient();
+  const { network: suiClientNetwork } = useSuiClientContext();
   const { mutate: disconnectSui } = useDisconnectWallet();
   const { mutateAsync: signAndExecute } = useSignAndExecuteTransaction();
   const suiAddress = suiAccount?.address;
   const suiConnected = !!suiAccount;
-  const suiNetwork = useTestnet ? "testnet" : "mainnet";
+  const suiNetwork = suiClientNetwork as 'mainnet' | 'testnet';
 
   // Query SuiNS names for connected Sui wallet
   const { data: suiNamesData, isLoading: fetchingSuiNames } = useQuery({
@@ -1224,9 +1226,14 @@ export default function GenerateKeys() {
                     exit={{ opacity: 0, x: -10 }}
                     className="space-y-5"
                   >
-                    <h2 className="font-display text-lg font-semibold text-foreground">
-                      Step 3 — Attach to SuiNS
-                    </h2>
+                    <div className="flex items-center justify-between gap-3">
+                      <h2 className="font-display text-lg font-semibold text-foreground">
+                        Step 3 — Attach to SuiNS
+                      </h2>
+                      <span className="shrink-0 inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-medium bg-[#4DA2FF]/10 text-[#4DA2FF] border border-[#4DA2FF]/25">
+                        {useSuiTestnet ? "Sui Testnet" : "Sui Mainnet"}
+                      </span>
+                    </div>
                     <p className="text-sm text-muted-foreground">
                       Connect a Sui wallet to link your SuiNS name to your meta-address.
                     </p>
@@ -1326,7 +1333,7 @@ export default function GenerateKeys() {
                                 </div>
                                 <Button variant="outline" size="sm" className="w-full" asChild>
                                   <a
-                                    href={useTestnet ? `https://testnet.suins.io/name/${encodeURIComponent(suinsUploadResult.suinsName)}` : `https://suins.io/name/${encodeURIComponent(suinsUploadResult.suinsName)}`}
+                                    href={useSuiTestnet ? `https://testnet.suins.io/name/${encodeURIComponent(suinsUploadResult.suinsName)}` : `https://suins.io/name/${encodeURIComponent(suinsUploadResult.suinsName)}`}
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="inline-flex items-center justify-center gap-1.5"
@@ -1342,8 +1349,8 @@ export default function GenerateKeys() {
                         ) : (
                           <p className="text-sm text-muted-foreground">
                             No SuiNS name found. Register a name at{" "}
-                            <a href={useTestnet ? "https://testnet.suins.io/" : "https://suins.io"} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
-                              {useTestnet ? "testnet.suins.io" : "suins.io"}
+                            <a href={useSuiTestnet ? "https://testnet.suins.io/" : "https://suins.io"} target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">
+                              {useSuiTestnet ? "testnet.suins.io" : "suins.io"}
                             </a>{" "}
                             first.
                           </p>

--- a/SPECTER-web/src/pages/SendPayment.tsx
+++ b/SPECTER-web/src/pages/SendPayment.tsx
@@ -2179,59 +2179,34 @@ export default function SendPayment() {
                       ) : (
                         <div className="flex flex-col items-center w-full relative">
                           <ReceiptConfetti />
-                          <AnimatedTicket
-                            ticketId={String(announcementId)}
-                            amount={verifiedTx ? parseFloat(verifiedTx.amountFormatted) : parseFloat(amount) || 0}
-                            date={new Date()}
-                            cardHolder={resolvedENS?.ens_name ?? "Recipient"}
-                            last4Digits={stealthResult.stealth_address.replace(/^0x/, "").slice(-4)}
-                            barcodeValue={`${announcementId}${stealthResult.stealth_address.slice(2, 14)}`}
-                            currency={getSendChainConfig(verifiedTx?.chain ?? publishChain).currencySymbol}
-                          />
-                          <div className="w-full max-w-lg mt-4 rounded-lg border border-white/[0.08] bg-black/35 p-4">
-                            <p className="font-display text-[10px] font-bold tracking-[0.16em] uppercase text-emerald-400/75 mb-3">
-                              Payment published successfully
-                            </p>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs">
-                              <div className="flex items-center gap-2 text-white/70">
-                                {getChainIcon(verifiedTx?.chain ?? publishChain, 15)}
-                                <span>Chain: {getSendChainConfig(verifiedTx?.chain ?? publishChain).label}</span>
-                              </div>
-                              <div className="text-white/70">
-                                Payment ID: <span className="font-mono">{stealthResult.payment_id.slice(0, 10)}...{stealthResult.payment_id.slice(-6)}</span>
-                              </div>
-                              <div className="text-white/70">
-                                Announcement: <span className="font-mono">#{announcementId}</span>
-                              </div>
-                              <div className="text-white/70">
-                                Tx: <span className="font-mono">{(verifiedTx?.txHash ?? pendingTxHash ?? "").slice(0, 10)}...{(verifiedTx?.txHash ?? pendingTxHash ?? "").slice(-6)}</span>
-                              </div>
-                              {monadTxHash && (
-                                <div className="text-white/70 md:col-span-2 flex items-center gap-1.5">
-                                  <span>
-                                    Monad announce:{" "}
-                                    <span className="font-mono">
-                                      {monadTxHash.slice(0, 10)}...{monadTxHash.slice(-6)}
-                                    </span>
-                                  </span>
-                                  {getExplorerTxUrl("monad", monadTxHash) && (
-                                    <a
-                                      href={getExplorerTxUrl("monad", monadTxHash)}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="text-primary/60 hover:text-primary transition-colors"
-                                      aria-label="View announce transaction on Monad explorer"
-                                    >
-                                      <ExternalLink className="h-3 w-3" />
-                                    </a>
-                                  )}
-                                </div>
-                              )}
-                            </div>
-                          </div>
+                          {(() => {
+                            const finalChain = verifiedTx?.chain ?? publishChain;
+                            const finalTxHash = verifiedTx?.txHash ?? pendingTxHash ?? undefined;
+                            const txExplorerUrl = finalTxHash ? getExplorerTxUrl(finalChain, finalTxHash) : undefined;
+                            const monadExplorerUrl = monadTxHash ? getExplorerTxUrl("monad", monadTxHash) : undefined;
+                            return (
+                              <AnimatedTicket
+                                ticketId={String(announcementId)}
+                                amount={verifiedTx ? parseFloat(verifiedTx.amountFormatted) : parseFloat(amount) || 0}
+                                date={new Date()}
+                                cardHolder={resolvedENS?.ens_name ?? "Recipient"}
+                                last4Digits={stealthResult.stealth_address.replace(/^0x/, "").slice(-4)}
+                                barcodeValue={`${announcementId}${stealthResult.stealth_address.slice(2, 14)}`}
+                                currency={getSendChainConfig(finalChain).currencySymbol}
+                                chainLabel={getSendChainConfig(finalChain).label}
+                                paymentId={stealthResult.payment_id}
+                                announcementId={announcementId ?? undefined}
+                                txHash={finalTxHash}
+                                txUrl={txExplorerUrl || undefined}
+                                monadTxHash={monadTxHash ?? undefined}
+                                monadTxUrl={monadExplorerUrl || undefined}
+                              />
+                            );
+                          })()}
                           <div className="flex flex-col gap-3 mt-6 w-full max-w-xs mx-auto">
                             <DownloadJsonButton
                               data={{
+                                network: getSendChainConfig(verifiedTx?.chain ?? publishChain).label,
                                 stealth_address: stealthResult.stealth_address,
                                 stealth_sui_address: stealthResult.stealth_sui_address,
                                 amount_evm: verifiedTx && verifiedTx.chain !== "sui" ? verifiedTx.amountFormatted : amount,
@@ -2240,14 +2215,20 @@ export default function SendPayment() {
                                 payment_id: stealthResult.payment_id,
                                 recipient: resolvedENS?.ens_name,
                                 tx_hash: verifiedTx?.txHash ?? pendingTxHash ?? undefined,
+                                tx_explorer_url: (verifiedTx?.txHash ?? pendingTxHash)
+                                  ? getExplorerTxUrl(verifiedTx?.chain ?? publishChain, verifiedTx?.txHash ?? pendingTxHash ?? "")
+                                  : undefined,
                                 monad_announce_tx_hash: monadTxHash ?? undefined,
+                                monad_announce_explorer_url: monadTxHash
+                                  ? getExplorerTxUrl("monad", monadTxHash)
+                                  : undefined,
                               }}
-                              filename="specter-payment-details.json"
-                              label="Download"
+                              filename="specter-payment-receipt.json"
+                              label="Download Receipt"
                               variant="outline"
                               size="default"
                               className="w-full"
-                              tooltip="Save receipt as JSON"
+                              tooltip="Save full receipt as JSON"
                             />
                             <Button variant="quantum" className="w-full" onClick={handleSendAnother}>
                               Send Another

--- a/specter/specter-api/src/dto.rs
+++ b/specter/specter-api/src/dto.rs
@@ -365,8 +365,10 @@ pub struct HealthResponse {
     pub version: String,
     pub uptime_seconds: u64,
     pub announcements_count: u64,
-    /// When true, backend uses testnet for SuiNS (ENS is always mainnet)
+    /// General EVM/Monad testnet flag.
     pub use_testnet: bool,
+    /// When true, backend resolves SuiNS against testnet registry (ENS is always mainnet).
+    pub use_sui_testnet: bool,
     /// True when RELAYER_PRIVATE_KEY is set and valid.
     pub relayer_ok: bool,
     /// True when Turso responds to a SELECT 1.

--- a/specter/specter-api/src/handlers.rs
+++ b/specter/specter-api/src/handlers.rs
@@ -547,6 +547,7 @@ pub async fn health_check(State(state): State<Arc<AppState>>) -> Json<HealthResp
         uptime_seconds: uptime,
         announcements_count: count,
         use_testnet: state.config.use_testnet,
+        use_sui_testnet: state.config.use_sui_testnet,
         relayer_ok,
         turso_ok,
         poller_last_block,

--- a/specter/specter-api/src/state.rs
+++ b/specter/specter-api/src/state.rs
@@ -63,8 +63,11 @@ impl RelayerConfig {
 pub struct ApiConfig {
     /// Ethereum mainnet RPC URL for ENS resolution.
     pub rpc_url: String,
-    /// When true, SuiNS and other non-ENS features use testnet defaults.
+    /// General testnet flag (controls Monad/EVM testnet behaviour).
     pub use_testnet: bool,
+    /// When true, SuiNS resolution uses testnet registry/package IDs.
+    /// Defaults to `use_testnet` when `USE_SUI_TESTNET` is not set.
+    pub use_sui_testnet: bool,
     /// Optional Pinata JWT used for pinning.
     pub pinata_jwt: Option<String>,
     /// Dedicated Pinata gateway (required for IPFS retrieves).
@@ -160,6 +163,7 @@ impl Default for ApiConfig {
         Self {
             rpc_url: DEFAULT_ETH_MAINNET_RPC.into(),
             use_testnet: false,
+            use_sui_testnet: false,
             pinata_jwt: None,
             pinata_gateway_url: String::new(),
             pinata_gateway_token: String::new(),
@@ -192,12 +196,19 @@ impl ApiConfig {
             .map(|v| v == "true" || v == "1")
             .unwrap_or(false);
 
+        // USE_SUI_TESTNET controls SuiNS registry/package selection independently
+        // of USE_TESTNET (which governs EVM/Monad behaviour). Defaults to USE_TESTNET
+        // when not explicitly set so existing single-flag setups keep working.
+        let use_sui_testnet = std::env::var("USE_SUI_TESTNET")
+            .map(|v| v == "true" || v == "1")
+            .unwrap_or(use_testnet);
+
         // ENS resolution always uses Ethereum mainnet — real .eth names are not on Sepolia.
         let rpc_url =
             std::env::var("ENS_RPC_URL").unwrap_or_else(|_| DEFAULT_ETH_MAINNET_RPC.into());
 
         let sui_rpc_url = std::env::var("SUI_RPC_URL").unwrap_or_else(|_| {
-            if use_testnet {
+            if use_sui_testnet {
                 DEFAULT_SUI_TESTNET_RPC.into()
             } else {
                 DEFAULT_SUI_MAINNET_RPC.into()
@@ -233,6 +244,7 @@ impl ApiConfig {
         Self {
             rpc_url,
             use_testnet,
+            use_sui_testnet,
             pinata_jwt: std::env::var("PINATA_JWT").ok(),
             pinata_gateway_url,
             pinata_gateway_token,
@@ -693,7 +705,7 @@ fn build_resolver(config: &ApiConfig) -> SpecterResolver {
 fn build_suins_resolver(config: &ApiConfig) -> SuinsResolver {
     let mut sc = SuinsResolverConfig::new(
         &config.sui_rpc_url,
-        config.use_testnet,
+        config.use_sui_testnet,
         &config.pinata_gateway_url,
         &config.pinata_gateway_token,
     );


### PR DESCRIPTION

- Add USE_SUI_TESTNET / VITE_USE_SUI_TESTNET env flags so SuiNS can use testnet while ENS stays on mainnet (independent of USE_TESTNET)
- Backend: propagate use_sui_testnet through ApiConfig, SuinsResolver, HealthResponse, and default SUI_RPC_URL selection
- Frontend: derive suiNetwork from useSuiClientContext() to stay in sync with the dapp-kit provider; label Sui chain as "Sui Testnet/Mainnet" with correct suiscan.xyz explorer URLs
- Move all payment details (Network, Announcement, Payment ID, Tx w/ explorer link, Monad announce w/ link) into AnimatedTicket; remove the separate "Payment published successfully" card below the ticket
- Add network badge chip to Step 3 (Attach to SuiNS) in GenerateKeys