### PR TITLE
feat(web): feedback channels, error pages, and 5x walkthrough prompt

### DIFF
--- a/SPECTER-web/src/App.tsx
+++ b/SPECTER-web/src/App.tsx
@@ -8,6 +8,8 @@ import { usePageTracking } from "@/hooks/usePageTracking";
 import { AnimatedGridPattern } from "@/components/ui/animations/animated-grid-pattern";
 import { Analytics } from "@vercel/analytics/react";
 import { WalkthroughVideoPrompt } from "@/components/features/WalkthroughVideoPrompt";
+import { FeedbackBubble } from "@/components/features/FeedbackBubble";
+import { ErrorBoundary } from "@/components/features/ErrorBoundary";
 import Index from "./pages/Index";
 import GenerateKeys from "./pages/GenerateKeys";
 import SendPayment from "./pages/SendPayment";
@@ -44,19 +46,22 @@ const App = () => (
           <div className="relative z-10">
             <ScrollToTop />
             <RouteTracker />
-            <Routes>
-              <Route path="/" element={<Index />} />
-              <Route path="/setup" element={<GenerateKeys />} />
-              <Route path="/send" element={<SendPayment />} />
-              <Route path="/scan" element={<ScanPayments />} />
-              <Route path="/yellow" element={<YellowPage />} />
-              <Route path="/usecases" element={<UseCasesPage />} />
-              <Route path="/insights" element={<InsightsPage />} />
-              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-              <Route path="*" element={<NotFound />} />
-            </Routes>
+            <ErrorBoundary>
+              <Routes>
+                <Route path="/" element={<Index />} />
+                <Route path="/setup" element={<GenerateKeys />} />
+                <Route path="/send" element={<SendPayment />} />
+                <Route path="/scan" element={<ScanPayments />} />
+                <Route path="/yellow" element={<YellowPage />} />
+                <Route path="/usecases" element={<UseCasesPage />} />
+                <Route path="/insights" element={<InsightsPage />} />
+                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </ErrorBoundary>
           </div>
           <WalkthroughVideoPrompt />
+          <FeedbackBubble />
           <Analytics />
         </div>
       </BrowserRouter>

--- a/SPECTER-web/src/components/features/ErrorBoundary.tsx
+++ b/SPECTER-web/src/components/features/ErrorBoundary.tsx
@@ -1,0 +1,62 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { ErrorScreen } from "@/components/features/ErrorScreen";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * Catches render-time errors anywhere below it and shows the retro-TV error
+ * screen (with feedback CTAs) instead of a blank white page.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("App crashed:", error, info.componentStack);
+  }
+
+  private handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center bg-background pt-20 pb-16 px-4">
+        <ErrorScreen
+          errorCode="500"
+          screenMessage="SIGNAL LOST"
+          title="Well, this is awkward"
+          description="Something glitched on our end and the screen went dark. A refresh usually brings it back — if not, we'd really like to hear from you."
+          actions={
+            <>
+              <button
+                type="button"
+                onClick={this.handleReload}
+                className="font-dm-sans inline-block select-none rounded-full bg-primary px-8 py-3 text-lg font-medium text-primary-foreground transition-opacity hover:opacity-90"
+              >
+                Reload page
+              </button>
+              <a
+                href="/"
+                className="font-dm-sans inline-block select-none rounded-full border border-border px-8 py-3 text-lg font-medium text-foreground/80 transition-colors hover:text-foreground"
+              >
+                Go to Home
+              </a>
+            </>
+          }
+        />
+      </div>
+    );
+  }
+}

--- a/SPECTER-web/src/components/features/ErrorScreen.tsx
+++ b/SPECTER-web/src/components/features/ErrorScreen.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from "react";
+import { MessageSquarePlus, CalendarClock } from "lucide-react";
+import { RetroTvError } from "@/components/ui/404-error-page";
+import { FEEDBACK_FORM_URL, SCHEDULE_CALL_URL } from "@/lib/feedback";
+
+interface ErrorScreenProps {
+  errorCode?: string;
+  /** Short text shown on the TV screen, e.g. "NOT FOUND". */
+  screenMessage?: string;
+  title: string;
+  description: string;
+  /** Primary action(s) — e.g. a "Go home" link or "Reload" button. */
+  actions?: ReactNode;
+}
+
+/**
+ * Full-page error layout: a retro-TV display up top, a short explanation, the
+ * caller's primary action, and a quiet "talk to us" feedback strip at the
+ * bottom (share feedback / book a call). Used by the 404 page and the global
+ * ErrorBoundary alike.
+ */
+export function ErrorScreen({
+  errorCode = "404",
+  screenMessage = "NOT FOUND",
+  title,
+  description,
+  actions,
+}: ErrorScreenProps) {
+  return (
+    <div className="flex w-full flex-col items-center px-4 text-center">
+      <div className="w-full max-w-2xl">
+        <RetroTvError errorCode={errorCode} errorMessage={screenMessage} />
+      </div>
+
+      <h1 className="font-dm-sans mt-2 select-none text-2xl font-bold text-foreground md:text-4xl">
+        {title}
+      </h1>
+      <p className="font-dm-sans mt-3 max-w-md select-none text-base text-muted-foreground md:text-lg">
+        {description}
+      </p>
+
+      {actions && <div className="mt-7 flex flex-wrap items-center justify-center gap-3">{actions}</div>}
+
+      {/* ── Quiet feedback strip ── */}
+      <div className="mt-12 w-full max-w-md rounded-2xl border border-border/50 bg-card/40 px-5 py-4 backdrop-blur-sm">
+        <p className="text-sm font-medium text-foreground/80">
+          Something not working as expected?
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Tell us what happened or grab 15 minutes with the team — we read every note.
+        </p>
+        <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:justify-center">
+          <a
+            href={FEEDBACK_FORM_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center justify-center gap-1.5 rounded-full bg-amber-500 px-4 py-2 text-xs font-bold text-zinc-950 shadow-sm shadow-amber-500/30 transition-all hover:bg-amber-400 active:scale-95"
+          >
+            <MessageSquarePlus className="h-3.5 w-3.5" />
+            Share feedback
+          </a>
+          <a
+            href={SCHEDULE_CALL_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center justify-center gap-1.5 rounded-full border border-border px-4 py-2 text-xs font-semibold text-foreground/80 transition-all hover:border-amber-500/40 hover:text-amber-300 active:scale-95"
+          >
+            <CalendarClock className="h-3.5 w-3.5" />
+            Book a 15-min call
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/SPECTER-web/src/components/features/FeedbackBubble.tsx
+++ b/SPECTER-web/src/components/features/FeedbackBubble.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { MessageSquarePlus, CalendarClock, X } from "lucide-react";
+import {
+  FEEDBACK_FORM_URL,
+  SCHEDULE_CALL_URL,
+  ISSUE_EVENT,
+  type IssueDetail,
+} from "@/lib/feedback";
+import { WalkthroughPromptMascot } from "@/components/features/WalkthroughPromptMascot";
+
+// Auto-dismiss after this long if the user doesn't interact.
+const AUTO_DISMISS_MS = 7_000;
+// Don't re-nag: once dismissed, stay quiet for this long even if more errors fire.
+const SNOOZE_MS = 60_000;
+
+/**
+ * A small, friendly bottom-left popup that appears when the app hits an error.
+ * Offers two low-pressure ways out: a quick feedback form or a 15-min call.
+ * Auto-dismisses after 7s, or immediately when the user taps the cross.
+ *
+ * Triggered by:
+ *  • `toast.error(...)` anywhere (the sonner wrapper dispatches `specter:issue`)
+ *  • unhandled promise rejections
+ *  • a manual `reportIssue()` call
+ */
+export function FeedbackBubble() {
+  const [visible, setVisible] = useState(false);
+  const snoozedUntil = useRef(0);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const dismiss = () => {
+    if (timer.current) clearTimeout(timer.current);
+    snoozedUntil.current = Date.now() + SNOOZE_MS;
+    setVisible(false);
+  };
+
+  useEffect(() => {
+    const open = () => {
+      if (Date.now() < snoozedUntil.current) return;
+      setVisible(true);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => setVisible(false), AUTO_DISMISS_MS);
+    };
+
+    const onIssue = (_e: Event) => open();
+    const onRejection = () => open();
+
+    window.addEventListener(ISSUE_EVENT, onIssue as EventListener);
+    window.addEventListener("unhandledrejection", onRejection);
+    return () => {
+      window.removeEventListener(ISSUE_EVENT, onIssue as EventListener);
+      window.removeEventListener("unhandledrejection", onRejection);
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.aside
+          role="dialog"
+          aria-labelledby="fb-title"
+          initial={{ opacity: 0, y: 14, scale: 0.97 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: 8, scale: 0.97 }}
+          transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+          className="fixed bottom-4 left-4 z-[100] w-[min(100vw-2rem,17rem)] pointer-events-auto"
+        >
+          <div className="relative overflow-hidden rounded-2xl border border-amber-500/25 bg-zinc-950/95 shadow-[0_16px_48px_-8px_rgba(0,0,0,0.85),0_0_28px_-6px_rgba(245,158,11,0.18)] backdrop-blur-xl">
+            {/* Soft amber rim */}
+            <div
+              className="pointer-events-none absolute -inset-px rounded-[calc(1rem+1px)] opacity-40 z-0"
+              style={{
+                background:
+                  "linear-gradient(135deg,rgba(245,158,11,0.35) 0%,transparent 45%,transparent 60%,rgba(251,191,36,0.1) 100%)",
+              }}
+              aria-hidden
+            />
+
+            {/* Close */}
+            <button
+              type="button"
+              onClick={dismiss}
+              className="absolute top-2 right-2 z-30 flex h-6 w-6 items-center justify-center rounded-full bg-zinc-900/80 text-zinc-500 ring-1 ring-zinc-700/60 transition-all hover:text-zinc-200 hover:ring-amber-500/40"
+              aria-label="Dismiss"
+            >
+              <X className="h-3 w-3" />
+            </button>
+
+            <div className="relative z-10 p-4">
+              {/* Mascot + copy */}
+              <div className="flex items-start gap-3">
+                <div className="-mt-1 shrink-0">
+                  <WalkthroughPromptMascot className="scale-90" />
+                </div>
+                <div className="min-w-0 pt-1">
+                  <p
+                    id="fb-title"
+                    className="text-[13px] font-semibold leading-tight text-zinc-100"
+                  >
+                    Hit a snag?
+                  </p>
+                  <p className="mt-1 text-[11px] leading-snug text-zinc-400">
+                    Tell us what happened, or grab 15 min with the team.
+                  </p>
+                </div>
+              </div>
+
+              {/* Uniform action pair */}
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                <a
+                  href={FEEDBACK_FORM_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex h-8 w-full items-center justify-center gap-1.5 rounded-full bg-amber-500 px-2 text-[11px] font-bold text-zinc-950 shadow-sm shadow-amber-500/30 transition-all hover:bg-amber-400 active:scale-95"
+                >
+                  <MessageSquarePlus className="h-3 w-3 shrink-0" />
+                  Feedback
+                </a>
+                <a
+                  href={SCHEDULE_CALL_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex h-8 w-full items-center justify-center gap-1.5 rounded-full border border-zinc-700/70 px-2 text-[11px] font-semibold text-zinc-300 transition-all hover:border-amber-500/40 hover:text-amber-200 active:scale-95"
+                >
+                  <CalendarClock className="h-3 w-3 shrink-0" />
+                  Book a call
+                </a>
+              </div>
+            </div>
+          </div>
+        </motion.aside>
+      )}
+    </AnimatePresence>
+  );
+}
+
+// Re-exported for convenience so callers can trigger the bubble directly.
+export type { IssueDetail };

--- a/SPECTER-web/src/components/features/WalkthroughVideoPrompt.tsx
+++ b/SPECTER-web/src/components/features/WalkthroughVideoPrompt.tsx
@@ -4,9 +4,10 @@ import { Play, X } from "lucide-react";
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
 import {
-  hasSeenWalkthroughPrompt,
   isSpecterProductionHost,
   markWalkthroughPromptSeen,
+  recordWalkthroughPromptView,
+  shouldShowWalkthroughPrompt,
 } from "@/lib/walkthroughPrompt";
 import {
   SPECTER_WALKTHROUGH_THUMBNAIL_URL,
@@ -18,7 +19,7 @@ const ALLOWED_PATHS = new Set(["/", "/insights"]);
 
 export function WalkthroughVideoPrompt() {
   const { pathname } = useLocation();
-  const [dismissed, setDismissed] = useState(() => hasSeenWalkthroughPrompt());
+  const [dismissed, setDismissed] = useState(() => !shouldShowWalkthroughPrompt());
 
   const dismiss = () => {
     markWalkthroughPromptSeen();
@@ -36,6 +37,11 @@ export function WalkthroughVideoPrompt() {
   }, [pathname]);
 
   const visible = !dismissed && ALLOWED_PATHS.has(pathname) && isSpecterProductionHost();
+
+  // Count this appearance toward the lifetime cap (once per session).
+  useEffect(() => {
+    if (visible) recordWalkthroughPromptView();
+  }, [visible]);
 
   return (
     <AnimatePresence>
@@ -99,7 +105,7 @@ export function WalkthroughVideoPrompt() {
               {/* Tag line — right of mascot */}
               <div className="absolute right-3 top-1/2 -translate-y-1/2 text-right z-10">
                 <span className="block text-[9px] font-bold uppercase tracking-[0.18em] text-amber-400/70 mb-0.5">
-                  First visit
+                  Quick start
                 </span>
                 <span
                   className="block font-black leading-none tracking-tight text-zinc-200"

--- a/SPECTER-web/src/components/layout/Footer.tsx
+++ b/SPECTER-web/src/components/layout/Footer.tsx
@@ -1,8 +1,16 @@
 import { Link } from "react-router-dom";
-import { Github, BookOpen, MonitorPlay, Rss } from "lucide-react";
+import {
+  Github,
+  BookOpen,
+  MonitorPlay,
+  Rss,
+  MessageSquarePlus,
+  CalendarClock,
+} from "lucide-react";
 import { Button } from "@/components/ui/base/button";
 import { XLogo } from "@/components/features/insights/XLogo";
 import { getAppDeployment } from "@/lib/appEnv";
+import { FEEDBACK_FORM_URL, SCHEDULE_CALL_URL } from "@/lib/feedback";
 import { cn } from "@/lib/utils";
 
 /** npm brand mark (Simple Icons), inherits `currentColor` for theme consistency */
@@ -78,6 +86,32 @@ export function Footer() {
               <span>Insights</span>
             </Link>
           </div>
+
+          {/* Talk to us — centered, quiet, but always reachable */}
+          <div className="flex flex-col gap-2 mt-6 md:mt-0 md:items-center">
+            <span className="font-display text-[9px] font-semibold uppercase tracking-[0.22em] text-muted-foreground/40 select-none">
+              Talk to us
+            </span>
+            <a
+              href={FEEDBACK_FORM_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={devLinkClass}
+            >
+              <MessageSquarePlus className="h-4 w-4 shrink-0" />
+              <span>Share feedback</span>
+            </a>
+            <a
+              href={SCHEDULE_CALL_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={devLinkClass}
+            >
+              <CalendarClock className="h-4 w-4 shrink-0" />
+              <span>Book a 15-min call</span>
+            </a>
+          </div>
+
           <div className="flex flex-col gap-4 mt-6 md:mt-0 md:items-end">
             <ul className="flex list-none gap-3 md:justify-end">
               {socialLinks.map((link, i) => (

--- a/SPECTER-web/src/components/ui/404-error-page.tsx
+++ b/SPECTER-web/src/components/ui/404-error-page.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+interface RetroTvErrorProps extends React.HTMLAttributes<HTMLDivElement> {
+  errorCode?: string;
+  errorMessage?: string;
+}
+
+const RetroTvError = React.forwardRef<HTMLDivElement, RetroTvErrorProps>(
+  (
+    {
+      className,
+      errorCode = '404',
+      errorMessage = 'NOT FOUND',
+      ...props
+    },
+    ref
+  ) => {
+    // Splits the error code into individual characters
+    const errorCodeDigits = errorCode.split('');
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'main_wrapper flex items-center justify-center', // Using utility classes for basic layout
+          className
+        )}
+        {...props}
+      >
+        <div className="main">
+          <div className="antenna">
+            <div className="antenna_shadow"></div>
+            <div className="a1"></div>
+            <div className="a1d"></div>
+            <div className="a2"></div>
+            <div className="a2d"></div>
+            <div className="a_base"></div>
+          </div>
+          <div className="tv">
+            <div className="cruve">
+              <svg
+                viewBox="0 0 189.929 189.929"
+                xmlns="http://www.w3.org/2000/svg"
+                className="curve_svg"
+              >
+                <path d="M70.343,70.343c-30.554,30.553-44.806,72.7-39.102,115.635l-29.738,3.951C-5.442,137.659,11.917,86.34,49.129,49.13C86.34,11.918,137.664-5.445,189.928,1.502l-3.95,29.738C143.041,25.54,100.895,39.789,70.343,70.343z" />
+              </svg>
+            </div>
+            <div className="display_div">
+              <div className="screen_out">
+                <div className="screen_out1">
+                  <div className="screen">
+                    <span className="notfound_text">{errorMessage}</span>
+                  </div>
+                  <div className="screenM">
+                    <span className="notfound_text">{errorMessage}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="lines">
+              <div className="line1"></div>
+              <div className="line2"></div>
+              <div className="line3"></div>
+            </div>
+            <div className="buttons_div">
+              <div className="b1">
+                <div></div>
+              </div>
+              <div className="b2"></div>
+              <div className="speakers">
+                <div className="g1">
+                  <div className="g11"></div>
+                  <div className="g12"></div>
+                  <div className="g13"></div>
+                </div>
+                <div className="g"></div>
+                <div className="g"></div>
+              </div>
+            </div>
+          </div>
+          <div className="bottom">
+            <div className="base1"></div>
+            <div className="base2"></div>
+            <div className="base3"></div>
+          </div>
+        </div>
+        <div className="text_404">
+          {/* Map over the error code digits to render them */}
+          {errorCodeDigits.map((digit, index) => (
+            <div key={index} className={`text_404${index + 1}`}>
+              {digit}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+);
+
+RetroTvError.displayName = 'RetroTvError';
+
+export { RetroTvError };

--- a/SPECTER-web/src/components/ui/base/sonner.tsx
+++ b/SPECTER-web/src/components/ui/base/sonner.tsx
@@ -1,6 +1,23 @@
-import { Toaster as Sonner, toast } from "sonner";
+import { Toaster as Sonner, toast as sonnerToast } from "sonner";
+import { reportIssue } from "@/lib/feedback";
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
+
+// Wrap sonner's `toast` so any surfaced error also offers a way to reach us
+// (feedback form / call) via the bottom-left FeedbackBubble. Every existing
+// `toast.error(...)` call site gets this for free.
+const baseError = sonnerToast.error;
+const toast = Object.assign(
+  (...args: Parameters<typeof sonnerToast>) => sonnerToast(...args),
+  sonnerToast,
+  {
+    error: ((...args: Parameters<typeof sonnerToast.error>) => {
+      const message = typeof args[0] === "string" ? args[0] : undefined;
+      reportIssue({ message });
+      return baseError(...args);
+    }) as typeof sonnerToast.error,
+  },
+);
 
 const Toaster = ({ ...props }: ToasterProps) => (
   <Sonner

--- a/SPECTER-web/src/index.css
+++ b/SPECTER-web/src/index.css
@@ -470,3 +470,352 @@
   background: rgba(234, 179, 8, 0.2);
   box-shadow: 0 0 20px rgba(234, 179, 8, 0.3);
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Retro TV error display (RetroTvError — src/components/ui/404-error-page.tsx)
+   All selectors are scoped under `.main_wrapper` so the generic class names
+   (.main, .tv, .screen, .bottom, .lines …) can't collide with app styles.
+   Themed to SPECTER's gold-plastic-on-midnight look.
+   ────────────────────────────────────────────────────────────────────────── */
+
+@keyframes b {
+  100% {
+    background-position: 50% 0, 60% 50%;
+  }
+}
+
+@keyframes tv-flicker {
+  0%, 97%, 100% { opacity: 1; }
+  98% { opacity: 0.82; }
+  99% { opacity: 0.94; }
+}
+
+.main_wrapper {
+  position: relative;
+  width: 100%;
+  min-height: 360px;
+  --tv-gold: #e7b15a;
+  --tv-gold-dark: #b07d2c;
+  --tv-shadow: #6e4f17;
+  --tv-bezel: #2a2113;
+  --tv-amber: #f5b942;
+}
+
+.main_wrapper .main {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ── Antenna ── */
+.main_wrapper .antenna {
+  width: 5px;
+  height: 50px;
+  border-radius: 50px;
+  background-color: #9aa0aa;
+  margin-bottom: -14px;
+  z-index: 0;
+  position: relative;
+}
+.main_wrapper .antenna_shadow {
+  position: absolute;
+  background-color: transparent;
+  width: 50px;
+  height: 56px;
+  margin-left: 1.5px;
+  border-radius: 20%;
+  transform: rotate(140deg);
+  border: 4px solid transparent;
+  box-shadow: inset 0 16px #777c86, inset 0 16px 1px 1px #777c86;
+}
+.main_wrapper .a1 {
+  position: absolute;
+  width: 5px;
+  height: 36px;
+  border-radius: 50px;
+  background-color: #b8bdc6;
+  transform: rotate(-25deg);
+  margin-top: -28px;
+  margin-left: -1px;
+}
+.main_wrapper .a1d {
+  transform: rotate(-25deg);
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background-color: #d9dde3;
+  border-radius: 50%;
+  margin-top: -53px;
+  margin-left: -16px;
+  z-index: 99;
+}
+.main_wrapper .a2 {
+  position: absolute;
+  width: 5px;
+  height: 36px;
+  border-radius: 50px;
+  background-color: #b8bdc6;
+  transform: rotate(25deg);
+  margin-top: -28px;
+  margin-left: 1px;
+}
+.main_wrapper .a2d {
+  transform: rotate(25deg);
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background-color: #d9dde3;
+  border-radius: 50%;
+  margin-top: -53px;
+  margin-left: 17px;
+  z-index: 99;
+}
+.main_wrapper .a_base {
+  background: linear-gradient(180deg, var(--tv-gold) 0%, var(--tv-gold-dark) 100%);
+  width: 50px;
+  height: 12px;
+  margin-top: 36px;
+  border-radius: 50px 50px 7px 7px;
+  z-index: 1;
+}
+
+/* ── TV body ── */
+.main_wrapper .tv {
+  width: 360px;
+  height: 270px;
+  margin-top: 14px;
+  border-radius: 18px;
+  background: linear-gradient(165deg, var(--tv-gold) 0%, var(--tv-gold-dark) 70%, var(--tv-shadow) 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 18px;
+  position: relative;
+  box-shadow:
+    inset 3px 3px 6px rgba(255, 236, 196, 0.55),
+    inset -4px -4px 10px rgba(0, 0, 0, 0.35),
+    0 22px 40px -14px rgba(0, 0, 0, 0.75),
+    0 0 38px -10px rgba(245, 185, 66, 0.35);
+}
+.main_wrapper .cruve {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  width: 14px;
+  height: 14px;
+  opacity: 0.55;
+  pointer-events: none;
+}
+.main_wrapper .curve_svg {
+  width: 100%;
+  height: 100%;
+  fill: rgba(255, 240, 205, 0.6);
+}
+
+/* ── Screen ── */
+.main_wrapper .display_div {
+  flex: 1;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.main_wrapper .screen_out {
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+  background: var(--tv-bezel);
+  padding: 10px;
+  box-shadow:
+    inset 2px 2px 5px rgba(0, 0, 0, 0.7),
+    inset -2px -2px 4px rgba(255, 220, 160, 0.18);
+}
+.main_wrapper .screen_out1 {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 9px;
+  overflow: hidden;
+}
+.main_wrapper .screen {
+  width: 100%;
+  height: 100%;
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background:
+    radial-gradient(ellipse at 50% 40%, rgba(245, 185, 66, 0.12), transparent 70%),
+    repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.035) 0 2px, transparent 2px 4px),
+    #0c0d11;
+  box-shadow: inset 0 0 26px 6px rgba(0, 0, 0, 0.9);
+  animation: tv-flicker 6s linear infinite;
+}
+.main_wrapper .screenM {
+  position: absolute;
+  inset: 0;
+  border-radius: 9px;
+  pointer-events: none;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.12) 0%, transparent 35%, transparent 70%, rgba(255, 255, 255, 0.05) 100%);
+}
+.main_wrapper .screenM .notfound_text {
+  display: none;
+}
+.main_wrapper .notfound_text {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-weight: 700;
+  font-size: 1.5rem;
+  letter-spacing: 0.18em;
+  color: var(--tv-amber);
+  text-shadow: 0 0 8px rgba(245, 185, 66, 0.85), 0 0 22px rgba(245, 185, 66, 0.45);
+  text-align: center;
+  padding: 0 6px;
+}
+
+/* ── Decorative tuner lines on the control column ── */
+.main_wrapper .lines {
+  position: absolute;
+  top: 22px;
+  right: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.main_wrapper .line1,
+.main_wrapper .line2,
+.main_wrapper .line3 {
+  height: 2px;
+  border-radius: 2px;
+  background: rgba(42, 33, 19, 0.55);
+}
+.main_wrapper .line1 { width: 26px; }
+.main_wrapper .line2 { width: 20px; }
+.main_wrapper .line3 { width: 14px; }
+
+/* ── Right-hand control panel ── */
+.main_wrapper .buttons_div {
+  width: 64px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 14px;
+  padding-top: 4px;
+}
+.main_wrapper .b1,
+.main_wrapper .b2 {
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #fbe2ad, var(--tv-gold-dark) 75%, var(--tv-shadow));
+  box-shadow: inset -2px -2px 4px rgba(0, 0, 0, 0.4), inset 2px 2px 3px rgba(255, 240, 205, 0.7), 0 2px 4px rgba(0, 0, 0, 0.35);
+  position: relative;
+}
+.main_wrapper .b1 {
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.main_wrapper .b1 > div {
+  width: 3px;
+  height: 13px;
+  border-radius: 3px;
+  background: var(--tv-bezel);
+  transform: translateY(-3px) rotate(28deg);
+}
+.main_wrapper .b2 {
+  width: 26px;
+  height: 26px;
+}
+
+/* ── Speaker grille ── */
+.main_wrapper .speakers {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+}
+.main_wrapper .g1 {
+  display: flex;
+  gap: 3px;
+  margin-bottom: 2px;
+}
+.main_wrapper .g11,
+.main_wrapper .g12,
+.main_wrapper .g13 {
+  width: 8px;
+  height: 4px;
+  border-radius: 2px;
+}
+.main_wrapper .g11 { background: #d9534f; }
+.main_wrapper .g12 { background: #e7c84f; }
+.main_wrapper .g13 { background: #5fae5f; }
+.main_wrapper .speakers .g {
+  width: 40px;
+  height: 13px;
+  border-radius: 4px;
+  background-color: var(--tv-bezel);
+  background-image:
+    radial-gradient(rgba(255, 224, 170, 0.35) 1px, transparent 1.4px),
+    radial-gradient(rgba(0, 0, 0, 0.5) 1px, transparent 1.4px);
+  background-size: 6px 6px, 6px 6px;
+  background-position: 0 0, 3px 3px;
+  animation: b 0.7s steps(2) infinite;
+}
+
+/* ── Stand / legs ── */
+.main_wrapper .bottom {
+  position: relative;
+  width: 360px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.main_wrapper .base1 {
+  width: 90px;
+  height: 14px;
+  background: linear-gradient(180deg, var(--tv-gold-dark), var(--tv-shadow));
+  border-radius: 0 0 6px 6px;
+}
+.main_wrapper .base2 {
+  width: 130px;
+  height: 10px;
+  background: linear-gradient(180deg, var(--tv-gold), var(--tv-gold-dark));
+  border-radius: 7px;
+}
+.main_wrapper .base3 {
+  width: 200px;
+  height: 8px;
+  margin-top: -2px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.45);
+  filter: blur(2px);
+}
+
+/* ── Giant translucent error code behind the set ── */
+.main_wrapper .text_404 {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14rem;
+  pointer-events: none;
+}
+.main_wrapper .text_404 > div {
+  font-family: "Signika", "Space Grotesk", sans-serif;
+  font-weight: 700;
+  font-size: clamp(7rem, 22vw, 15rem);
+  line-height: 1;
+  color: rgba(245, 185, 66, 0.10);
+  text-shadow: 0 0 40px rgba(245, 185, 66, 0.08);
+  user-select: none;
+}

--- a/SPECTER-web/src/lib/feedback.ts
+++ b/SPECTER-web/src/lib/feedback.ts
@@ -1,0 +1,26 @@
+// Lightweight feedback / support hooks shared across the app.
+//
+// Two ways for users to reach us:
+//  • a short form (async, low-friction)
+//  • a 15-min call (high-bandwidth, for the gnarly stuff)
+//
+// `reportIssue()` lets any part of the app surface the help bubble when
+// something goes wrong. The sonner wrapper calls it on every `toast.error`,
+// so existing error paths get this for free.
+
+export const FEEDBACK_FORM_URL = "https://forms.gle/bDC4Sa5GqFedrf688";
+export const SCHEDULE_CALL_URL = "https://calendly.com/pranshurastogi/15min";
+
+/** Window event the FeedbackBubble listens for. */
+export const ISSUE_EVENT = "specter:issue";
+
+export interface IssueDetail {
+  /** Optional short context, e.g. the error message that triggered this. */
+  message?: string;
+}
+
+/** Surface the help bubble. Safe to call from anywhere (no-op during SSR). */
+export function reportIssue(detail?: IssueDetail): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent<IssueDetail>(ISSUE_EVENT, { detail }));
+}

--- a/SPECTER-web/src/lib/walkthroughPrompt.ts
+++ b/SPECTER-web/src/lib/walkthroughPrompt.ts
@@ -1,4 +1,8 @@
-const STORAGE_KEY = "specter_walkthrough_prompt_seen";
+const VIEWS_KEY = "specter_walkthrough_prompt_views";
+const SESSION_FLAG = "specter_walkthrough_prompt_session";
+
+/** How many times (across sessions) the walkthrough prompt may auto-appear. */
+export const WALKTHROUGH_PROMPT_MAX_VIEWS = 5;
 
 const WALKTHROUGH_PROMPT_HOSTS = new Set([
   "specterpq.com",
@@ -14,22 +18,61 @@ export function isSpecterProductionHost(hostname?: string): boolean {
   return WALKTHROUGH_PROMPT_HOSTS.has(host);
 }
 
-export function hasSeenWalkthroughPrompt(): boolean {
+/** Lifetime number of times the prompt has been shown to this visitor. */
+export function getWalkthroughPromptViews(): number {
   try {
-    return localStorage.getItem(STORAGE_KEY) === "1";
+    return Number.parseInt(localStorage.getItem(VIEWS_KEY) ?? "0", 10) || 0;
   } catch {
-    return true;
+    // localStorage unavailable — treat as exhausted so we never nag.
+    return WALKTHROUGH_PROMPT_MAX_VIEWS;
   }
 }
 
+/** True once the prompt has been shown its full allotment of times. */
+export function hasSeenWalkthroughPrompt(): boolean {
+  return getWalkthroughPromptViews() >= WALKTHROUGH_PROMPT_MAX_VIEWS;
+}
+
+/** Whether the prompt has already been counted/shown in this browser session. */
+export function shownThisSession(): boolean {
+  try {
+    return sessionStorage.getItem(SESSION_FLAG) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Record that the prompt was shown. Counts at most once per session toward the
+ * lifetime cap, so the visitor sees it across up to {@link WALKTHROUGH_PROMPT_MAX_VIEWS}
+ * sessions rather than repeatedly within one.
+ */
+export function recordWalkthroughPromptView(): void {
+  if (shownThisSession()) return;
+  try {
+    sessionStorage.setItem(SESSION_FLAG, "1");
+    localStorage.setItem(VIEWS_KEY, String(getWalkthroughPromptViews() + 1));
+  } catch {
+    // storage unavailable — silently skip
+  }
+}
+
+/**
+ * User dismissed the prompt — hide it for the rest of this session. The view was
+ * already counted when it appeared, so we only need to mute it until next visit.
+ */
 export function markWalkthroughPromptSeen(): void {
   try {
-    localStorage.setItem(STORAGE_KEY, "1");
+    sessionStorage.setItem(SESSION_FLAG, "1");
   } catch {
-    // localStorage unavailable — silently skip
+    // storage unavailable — silently skip
   }
 }
 
 export function shouldShowWalkthroughPrompt(hostname?: string): boolean {
-  return isSpecterProductionHost(hostname) && !hasSeenWalkthroughPrompt();
+  return (
+    isSpecterProductionHost(hostname) &&
+    !hasSeenWalkthroughPrompt() &&
+    !shownThisSession()
+  );
 }

--- a/SPECTER-web/src/pages/NotFound.tsx
+++ b/SPECTER-web/src/pages/NotFound.tsx
@@ -1,66 +1,8 @@
 import { useLocation, Link } from "react-router-dom";
 import { useEffect } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import { Ghost } from "lucide-react";
 import { Header } from "@/components/layout/Header";
 import { Footer } from "@/components/layout/Footer";
-
-const ease = [0.43, 0.13, 0.23, 0.96] as const;
-
-const containerVariants = {
-  hidden: { opacity: 0, y: 30 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.7,
-      ease,
-      delayChildren: 0.1,
-      staggerChildren: 0.1,
-    },
-  },
-};
-
-const itemVariants = {
-  hidden: { opacity: 0, y: 20 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: { duration: 0.6, ease },
-  },
-};
-
-const numberVariants = {
-  hidden: (direction: number) => ({
-    opacity: 0,
-    x: direction * 40,
-    y: 15,
-    rotate: direction * 5,
-  }),
-  visible: {
-    opacity: 0.7,
-    x: 0,
-    y: 0,
-    rotate: 0,
-    transition: { duration: 0.8, ease },
-  },
-};
-
-const ghostVariants = {
-  hidden: { scale: 0.8, opacity: 0, y: 15, rotate: -5 },
-  visible: {
-    scale: 1,
-    opacity: 1,
-    y: 0,
-    rotate: 0,
-    transition: { duration: 0.6, ease },
-  },
-  hover: {
-    scale: 1.1,
-    y: -10,
-    transition: { duration: 0.3, ease },
-  },
-};
+import { ErrorScreen } from "@/components/features/ErrorScreen";
 
 const NotFound = () => {
   const location = useLocation();
@@ -72,83 +14,21 @@ const NotFound = () => {
   return (
     <div className="min-h-screen flex flex-col">
       <Header />
-      <main className="flex-1 flex items-center justify-center pt-28 pb-12 px-4">
-        <AnimatePresence mode="wait">
-          <motion.div
-            className="text-center"
-            variants={containerVariants}
-            initial="hidden"
-            animate="visible"
-            exit="hidden"
-          >
-            <div className="flex items-center justify-center gap-4 md:gap-6 mb-8 md:mb-12">
-              <motion.span
-                className="text-[80px] md:text-[120px] font-bold text-foreground/70 font-signika select-none"
-                variants={numberVariants}
-                custom={-1}
-              >
-                4
-              </motion.span>
-              <motion.div
-                variants={ghostVariants}
-                initial="hidden"
-                animate={{
-                  scale: 1,
-                  opacity: 1,
-                  y: [0, -6, 0],
-                  rotate: 0,
-                  transition: {
-                    duration: 0.6,
-                    ease,
-                    y: { duration: 2.5, repeat: Infinity, ease: "easeInOut" },
-                  },
-                }}
-                whileHover="hover"
-              >
-                <Ghost
-                  className="w-[80px] h-[80px] md:w-[120px] md:h-[120px] text-foreground/80"
-                  strokeWidth={1.5}
-                />
-              </motion.div>
-              <motion.span
-                className="text-[80px] md:text-[120px] font-bold text-foreground/70 font-signika select-none"
-                variants={numberVariants}
-                custom={1}
-              >
-                4
-              </motion.span>
-            </div>
-
-            <motion.h1
-              className="text-3xl md:text-5xl font-bold text-foreground mb-4 md:mb-6 opacity-90 font-dm-sans select-none"
-              variants={itemVariants}
+      <main className="flex-1 flex items-center justify-center pt-28 pb-16 px-4">
+        <ErrorScreen
+          errorCode="404"
+          screenMessage="NOT FOUND"
+          title="Lost in the static"
+          description="This page must be a ghost — we couldn't tune it in. Let's get you back to a working channel."
+          actions={
+            <Link
+              to="/"
+              className="font-dm-sans inline-block select-none rounded-full bg-primary px-8 py-3 text-lg font-medium text-primary-foreground transition-opacity hover:opacity-90"
             >
-              Boo! Page missing!
-            </motion.h1>
-
-            <motion.p
-              className="text-lg md:text-xl text-muted-foreground mb-8 md:mb-12 font-dm-sans select-none"
-              variants={itemVariants}
-            >
-              Whoops! This page must be a ghost — it&apos;s not here!
-            </motion.p>
-
-            <motion.div
-              variants={itemVariants}
-              whileHover={{
-                scale: 1.05,
-                transition: { duration: 0.3, ease },
-              }}
-            >
-              <Link
-                to="/"
-                className="inline-block bg-primary text-primary-foreground px-8 py-3 rounded-full text-lg font-medium hover:opacity-90 transition-opacity font-dm-sans select-none"
-              >
-                Go to Home
-              </Link>
-            </motion.div>
-          </motion.div>
-        </AnimatePresence>
+              Go to Home
+            </Link>
+          }
+        />
       </main>
       <Footer />
     </div>

--- a/SPECTER-web/src/test/walkthroughPrompt.test.ts
+++ b/SPECTER-web/src/test/walkthroughPrompt.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
+  WALKTHROUGH_PROMPT_MAX_VIEWS,
+  getWalkthroughPromptViews,
   hasSeenWalkthroughPrompt,
   isSpecterProductionHost,
   markWalkthroughPromptSeen,
+  recordWalkthroughPromptView,
   shouldShowWalkthroughPrompt,
 } from "@/lib/walkthroughPrompt";
 
 describe("walkthroughPrompt", () => {
   beforeEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
   });
 
   it("recognizes allowed hosts", () => {
@@ -25,9 +29,32 @@ describe("walkthroughPrompt", () => {
     expect(shouldShowWalkthroughPrompt("localhost")).toBe(true);
   });
 
-  it("does not show again after dismiss", () => {
+  it("counts at most one view per session", () => {
+    recordWalkthroughPromptView();
+    recordWalkthroughPromptView();
+    expect(getWalkthroughPromptViews()).toBe(1);
+  });
+
+  it("hides for the rest of the session once dismissed", () => {
+    recordWalkthroughPromptView();
     markWalkthroughPromptSeen();
+    expect(shouldShowWalkthroughPrompt("specterpq.com")).toBe(false);
+    // ...but it isn't permanently retired until the cap is reached.
+    expect(hasSeenWalkthroughPrompt()).toBe(false);
+  });
+
+  it("reappears across sessions until the view cap is reached", () => {
+    for (let i = 0; i < WALKTHROUGH_PROMPT_MAX_VIEWS; i++) {
+      // each iteration simulates a fresh session
+      sessionStorage.clear();
+      expect(shouldShowWalkthroughPrompt("specterpq.com")).toBe(true);
+      recordWalkthroughPromptView();
+    }
+    expect(getWalkthroughPromptViews()).toBe(WALKTHROUGH_PROMPT_MAX_VIEWS);
     expect(hasSeenWalkthroughPrompt()).toBe(true);
+
+    // A brand-new session no longer shows it.
+    sessionStorage.clear();
     expect(shouldShowWalkthroughPrompt("specterpq.com")).toBe(false);
   });
 });


### PR DESCRIPTION
- Add reusable feedback lib (form + 15-min call links) and reportIssue() event
- FeedbackBubble: bottom-left help popup on errors (mascot, uniform actions, auto-dismiss after 7s or on close); wired into toast.error globally
- Footer: centered "Talk to us" section (share feedback / book a call)
- Retro-TV error display (RetroTvError) + ErrorScreen with feedback strip
- Use ErrorScreen on the 404 page and a new global ErrorBoundary
- Walkthrough video prompt now shows up to 5 times (once per session) vs once