### PR TITLE
feat(pay): Dark Knight theme for pay link UI + remembered names

### DIFF
--- a/SPECTER-web/src/components/features/pay/PayLinkCard.tsx
+++ b/SPECTER-web/src/components/features/pay/PayLinkCard.tsx
@@ -11,16 +11,17 @@ import {
   ArrowRight,
   CheckCircle2,
   AlertCircle,
+  Clock,
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/base/card";
 import { Button } from "@/components/ui/base/button";
 import { Input } from "@/components/ui/base/input";
-import { Badge } from "@/components/ui/base/badge";
 import { CopyButton } from "@/components/ui/specialized/copy-button";
 import { QrCode, downloadQrPng } from "@/components/ui/specialized/qr-code";
 import { RequestPaymentDrawer } from "./RequestPaymentDrawer";
 import { getRegisteredName } from "@/lib/setupProgress";
 import { buildPayUrl, isValidRecipientName } from "@/lib/payLink";
+import { getMyPayNames, addMyPayName, clearMyPayNames } from "@/lib/myPayNames";
 import { api, ApiError } from "@/lib/api";
 import { analytics } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
@@ -39,6 +40,13 @@ const NOT_REGISTERED_CODES = new Set([
 
 const VERIFY_DEBOUNCE_MS = 600;
 
+/* Dark Knight palette — scoped to this card so it reads like a sealed object,
+ * not a slice of the app chrome. Void graphite surface, one signal-gold accent. */
+const goldBtn =
+  "bg-[#F2C94C] text-[#0B0D10] hover:bg-[#E5BE43] focus-visible:ring-[#F2C94C] border-0";
+const ghostBtn =
+  "border border-[#2A2E37] bg-transparent text-[#C7CBD2] hover:bg-[#15181E] hover:text-white";
+
 export function PayLinkCard({ source, className }: { source: "scan" | "setup"; className?: string }) {
   // A stored name comes from a completed setup, so it's already known-registered.
   const storedName = useMemo(() => getRegisteredName(), []);
@@ -49,6 +57,27 @@ export function PayLinkCard({ source, className }: { source: "scan" | "setup"; c
   const [showQr, setShowQr] = useState(false);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const reqId = useRef(0);
+
+  // Locally-remembered names this person has used for their own pay link,
+  // surfaced as suggestions next time — same pattern as the Send section.
+  const [savedNames, setSavedNames] = useState<string[]>(() => {
+    try { return getMyPayNames().map((r) => r.name); } catch { return []; }
+  });
+  const [inputFocused, setInputFocused] = useState(false);
+
+  const rememberName = useCallback((value: string) => {
+    addMyPayName(value);
+    setSavedNames(getMyPayNames().map((r) => r.name));
+  }, []);
+
+  // Suggestions = remembered names that match what's typed (or all, when empty),
+  // minus an exact match of the current value.
+  const typed = name.trim().toLowerCase();
+  const suggestions = useMemo(
+    () => savedNames.filter((n) => n !== typed && (!typed || n.includes(typed))),
+    [savedNames, typed]
+  );
+  const showSuggestions = isManualEntry && inputFocused && suggestions.length > 0;
 
   const url = useMemo(
     () => (status === "registered" && isValidRecipientName(name.toLowerCase()) ? buildPayUrl(name.toLowerCase()) : ""),
@@ -78,6 +107,7 @@ export function PayLinkCard({ source, className }: { source: "scan" | "setup"; c
       else await api.resolveEns(candidate);
       if (id !== reqId.current) return; // a newer keystroke superseded this check
       setStatus("registered");
+      rememberName(candidate);
       analytics.payLinkNameVerified(isSui ? "sui" : "ens");
     } catch (err) {
       if (id !== reqId.current) return;
@@ -90,7 +120,7 @@ export function PayLinkCard({ source, className }: { source: "scan" | "setup"; c
         setStatus("error");
       }
     }
-  }, []);
+  }, [rememberName]);
 
   // Debounce verification as the user types.
   useEffect(() => {
@@ -129,26 +159,33 @@ export function PayLinkCard({ source, className }: { source: "scan" | "setup"; c
   }
 
   return (
-    <Card className={cn("w-full overflow-hidden", className)}>
-      <CardContent className="p-5 space-y-4">
+    <Card
+      className={cn(
+        "w-full overflow-hidden border-[#1E222A] bg-[#0B0D10] text-[#EDEEF0]",
+        className
+      )}
+    >
+      {/* Bat-signal: a single gold beam across the top is the card's one bold note. */}
+      <div className="h-px w-full bg-gradient-to-r from-transparent via-[#F2C94C]/70 to-transparent" />
+      <CardContent className="p-5 space-y-5">
         {/* Header */}
         <div className="flex items-center gap-3">
-          <div className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-gradient-to-br from-primary to-accent text-white shadow-sm shadow-primary/30">
+          <div className="grid h-9 w-9 shrink-0 place-items-center rounded-xl border border-[#F2C94C]/30 bg-[#F2C94C]/10 text-[#F2C94C]">
             <Wallet className="h-4 w-4" />
           </div>
           <div className="min-w-0">
-            <h3 className="text-sm font-semibold leading-tight">Your pay link</h3>
-            <p className="text-xs text-muted-foreground">Share it anywhere to get paid privately</p>
+            <h3 className="text-sm font-semibold leading-tight text-[#F4F5F7]">Your pay link</h3>
+            <p className="text-xs text-[#878C96]">Share anywhere to get paid privately</p>
           </div>
-          <Badge variant="secondary" className="ml-auto shrink-0 text-[10px]">
-            private by default
-          </Badge>
+          <span className="ml-auto shrink-0 rounded-full border border-[#23262E] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-[#878C96]">
+            private
+          </span>
         </div>
 
         {/* Manual name entry (no stored name) with live verification */}
         {isManualEntry && (
           <div className="space-y-1.5">
-            <label htmlFor="paylink-name" className="text-xs text-muted-foreground">
+            <label htmlFor="paylink-name" className="text-xs text-[#878C96]">
               Your registered name
             </label>
             <div className="relative">
@@ -156,26 +193,67 @@ export function PayLinkCard({ source, className }: { source: "scan" | "setup"; c
                 id="paylink-name"
                 value={name}
                 onChange={(e) => setName(e.target.value.trim())}
+                onFocus={() => setInputFocused(true)}
+                // Delay so a suggestion click (onMouseDown) registers before close.
+                onBlur={() => window.setTimeout(() => setInputFocused(false), 120)}
                 placeholder="alice.eth or bob.sui"
-                className="font-mono text-sm pr-9"
+                className="border-[#23262E] bg-[#111317] font-mono text-sm text-[#EDEEF0] placeholder:text-[#5B616B] pr-9 focus-visible:ring-[#F2C94C]/60"
                 autoComplete="off"
                 spellCheck={false}
               />
               <div className="absolute right-3 top-1/2 -translate-y-1/2">
-                {status === "checking" && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
-                {status === "registered" && <CheckCircle2 className="h-4 w-4 text-emerald-500" />}
-                {status === "unregistered" && <AlertCircle className="h-4 w-4 text-amber-500" />}
+                {status === "checking" && <Loader2 className="h-4 w-4 animate-spin text-[#878C96]" />}
+                {status === "registered" && <CheckCircle2 className="h-4 w-4 text-emerald-400" />}
+                {status === "unregistered" && <AlertCircle className="h-4 w-4 text-[#F2C94C]" />}
               </div>
             </div>
-            {status === "invalid" && (
-              <p className="text-xs text-muted-foreground">Enter a name ending in .eth or .sui</p>
+
+            {/* Remembered names — rendered inline (not absolute) so the card's
+                overflow-hidden can't clip them and every row stays clickable. */}
+            {showSuggestions && (
+              <div className="overflow-hidden rounded-lg border border-[#23262E] bg-[#0E1014] animate-in fade-in slide-in-from-top-1 duration-150">
+                <div className="flex items-center justify-between px-3 pt-2 pb-1">
+                  <span className="text-[10px] uppercase tracking-[0.1em] text-[#5B616B]">Recent names</span>
+                  <button
+                    type="button"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      clearMyPayNames();
+                      setSavedNames([]);
+                    }}
+                    className="text-[10px] text-[#878C96] hover:text-[#F2C94C]"
+                  >
+                    Clear
+                  </button>
+                </div>
+                {suggestions.map((s) => (
+                  <button
+                    key={s}
+                    type="button"
+                    // onMouseDown beats the input's onBlur, so the value sticks.
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      setName(s);
+                      setInputFocused(false);
+                      void verify(s);
+                    }}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left font-mono text-sm text-[#C7CBD2] hover:bg-[#15181E] hover:text-white"
+                  >
+                    <Clock className="h-3.5 w-3.5 shrink-0 text-[#5B616B]" />
+                    <span className="truncate">{s}</span>
+                  </button>
+                ))}
+              </div>
             )}
-            {status === "checking" && <p className="text-xs text-muted-foreground">Checking SPECTER…</p>}
+            {status === "invalid" && (
+              <p className="text-xs text-[#878C96]">Enter a name ending in .eth or .sui</p>
+            )}
+            {status === "checking" && <p className="text-xs text-[#878C96]">Checking SPECTER…</p>}
             {status === "error" && (
               <button
                 type="button"
                 onClick={() => verify(name)}
-                className="text-xs text-primary hover:underline"
+                className="text-xs text-[#F2C94C] hover:underline"
               >
                 Couldn't verify right now — try again
               </button>
@@ -185,21 +263,26 @@ export function PayLinkCard({ source, className }: { source: "scan" | "setup"; c
 
         {/* Not set up on SPECTER → minimal setup suggestion */}
         {status === "unregistered" && (
-          <div className="rounded-lg border border-primary/20 bg-primary/5 p-4 space-y-3 animate-in fade-in slide-in-from-bottom-1 duration-200">
+          <div className="rounded-xl border border-[#F2C94C]/20 bg-[#F2C94C]/[0.06] p-4 space-y-3 animate-in fade-in slide-in-from-bottom-1 duration-200">
             <div className="flex items-start gap-3">
-              <div className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-primary/15 text-primary">
+              <div className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[#F2C94C]/15 text-[#F2C94C]">
                 <UserPlus className="h-4 w-4" />
               </div>
               <div className="space-y-0.5">
-                <p className="text-sm font-medium">
+                <p className="text-sm font-medium text-[#F4F5F7]">
                   <span className="font-mono">{name.toLowerCase()}</span> isn't on SPECTER yet
                 </p>
-                <p className="text-xs text-muted-foreground leading-relaxed">
+                <p className="text-xs text-[#878C96] leading-relaxed">
                   Set it up to start receiving private, post-quantum payments at this name.
                 </p>
               </div>
             </div>
-            <Button asChild size="sm" className="w-full" onClick={() => analytics.payLinkSetupCtaClicked()}>
+            <Button
+              asChild
+              size="sm"
+              className={cn("w-full", goldBtn)}
+              onClick={() => analytics.payLinkSetupCtaClicked()}
+            >
               <Link to="/setup">
                 Set up SPECTER <ArrowRight className="h-4 w-4 ml-1.5" />
               </Link>
@@ -210,46 +293,40 @@ export function PayLinkCard({ source, className }: { source: "scan" | "setup"; c
         {/* Registered → the shareable link, QR, and actions */}
         {status === "registered" && url && (
           <div className="space-y-4 animate-in fade-in duration-200">
-            <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-2">
-              <Link2 className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-              <span className="truncate font-mono text-xs">{url}</span>
+            <div className="flex items-center gap-2 rounded-lg border border-[#23262E] bg-[#111317] px-3 py-2.5">
+              <Link2 className="h-3.5 w-3.5 text-[#F2C94C] shrink-0" />
+              <span className="truncate font-mono text-xs text-[#C7CBD2]">{url}</span>
               <CopyButton
                 text={url}
                 onCopied={() => analytics.payLinkCopied("card")}
                 showLabel={false}
-                className="ml-auto"
+                className="ml-auto text-[#878C96] hover:text-white"
               />
             </div>
 
-            <p className="text-xs text-muted-foreground leading-relaxed">
+            <p className="text-xs text-[#878C96] leading-relaxed">
               Every payer gets a fresh, unlinkable stealth address — your link never exposes a reusable
-              address.
+              one.
             </p>
 
-            <div className="flex flex-wrap gap-2">
-              <Button variant="outline" size="sm" onClick={() => setShowQr((s) => !s)}>
+            <div className="grid grid-cols-2 gap-2">
+              <Button size="sm" className={ghostBtn} onClick={() => setShowQr((s) => !s)}>
                 <QrIcon className="h-4 w-4 mr-1.5" /> {showQr ? "Hide QR" : "Show QR"}
               </Button>
-              <Button variant="outline" size="sm" onClick={handleShare}>
+              <Button size="sm" className={ghostBtn} onClick={handleShare}>
                 <Share2 className="h-4 w-4 mr-1.5" /> Share
-              </Button>
-              <Button
-                size="sm"
-                onClick={() => {
-                  analytics.requestBuilderOpened();
-                  setDrawerOpen(true);
-                }}
-              >
-                Request an amount
               </Button>
             </div>
 
             {showQr && (
-              <div className="flex flex-col items-center gap-3 pt-1 animate-in fade-in zoom-in-95 duration-200">
-                <QrCode value={url} />
+              <div className="flex flex-col items-center gap-3 rounded-lg border border-[#23262E] bg-[#111317] p-4 animate-in fade-in zoom-in-95 duration-200">
+                <div className="rounded-lg bg-white p-2">
+                  <QrCode value={url} />
+                </div>
                 <Button
                   variant="ghost"
                   size="sm"
+                  className="text-[#C7CBD2] hover:bg-[#15181E] hover:text-white"
                   onClick={() => {
                     analytics.payLinkQrDownloaded("card");
                     downloadQrPng(url, `specter-${name.toLowerCase()}`);
@@ -260,13 +337,24 @@ export function PayLinkCard({ source, className }: { source: "scan" | "setup"; c
               </div>
             )}
 
+            <Button
+              size="sm"
+              className={cn("w-full", goldBtn)}
+              onClick={() => {
+                analytics.requestBuilderOpened();
+                setDrawerOpen(true);
+              }}
+            >
+              Request an amount
+            </Button>
+
             <RequestPaymentDrawer open={drawerOpen} onOpenChange={setDrawerOpen} recipient={name.toLowerCase()} />
           </div>
         )}
 
         {/* No name yet and nothing typed */}
         {status === "idle" && !isManualEntry && (
-          <p className="text-xs text-muted-foreground">
+          <p className="text-xs text-[#878C96]">
             Register an ENS or SuiNS name in Setup to get your shareable pay link.
           </p>
         )}

--- a/SPECTER-web/src/components/features/pay/PayLinkFab.tsx
+++ b/SPECTER-web/src/components/features/pay/PayLinkFab.tsx
@@ -89,7 +89,7 @@ export function PayLinkFab() {
             exit={reduce ? { opacity: 0 } : { opacity: 0, scale: 0.92, y: 14 }}
             transition={reduce ? { duration: 0.15 } : { type: "spring", stiffness: 380, damping: 30 }}
           >
-            <PayLinkCard source="scan" className="border-primary/25 shadow-2xl shadow-primary/25" />
+            <PayLinkCard source="scan" className="border-[#F2C94C]/25 shadow-2xl shadow-black/60" />
           </motion.div>
         )}
       </AnimatePresence>
@@ -123,13 +123,22 @@ export function PayLinkFab() {
           aria-expanded={open}
           whileHover={reduce ? undefined : { scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
-          className="peer relative grid h-16 w-16 cursor-grab place-items-center overflow-hidden rounded-[1.4rem] bg-gradient-to-br from-primary to-accent text-white shadow-xl shadow-primary/40 ring-1 ring-white/15 outline-none active:cursor-grabbing focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          className={cn(
+            "peer relative grid h-16 w-16 cursor-grab place-items-center rounded-full outline-none transition-colors active:cursor-grabbing",
+            "focus-visible:ring-2 focus-visible:ring-[#F2C94C] focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+            // Open = a quiet graphite disc behind the close icon; closed = bare orb, just the lottie.
+            open
+              ? "bg-[#15181E] text-[#EDEEF0] ring-1 ring-[#2A2E37] shadow-lg shadow-black/50"
+              : "bg-transparent"
+          )}
         >
-          {/* Idle pulse ring (closed only) */}
-          {!open && !reduce && (
-            <span
-              className="pointer-events-none absolute inset-0 rounded-[1.4rem] bg-primary/40 motion-safe:animate-ping"
-              style={{ animationDuration: "2.6s" }}
+          {/* Ambient bat-signal glow (closed only) — a soft gold breath, no box. */}
+          {!open && (
+            <motion.span
+              className="pointer-events-none absolute inset-1 rounded-full"
+              style={{ background: "radial-gradient(circle, rgba(242,201,76,0.30), transparent 68%)" }}
+              animate={reduce ? undefined : { opacity: [0.45, 0.85, 0.45], scale: [0.92, 1.04, 0.92] }}
+              transition={reduce ? undefined : { duration: 2.8, repeat: Infinity, ease: "easeInOut" }}
               aria-hidden="true"
             />
           )}
@@ -152,7 +161,8 @@ export function PayLinkFab() {
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.6 }}
                 transition={{ duration: 0.18 }}
-                className="relative grid h-14 w-14 place-items-center"
+                className="relative grid h-16 w-16 place-items-center"
+                style={{ filter: "drop-shadow(0 0 9px rgba(242,201,76,0.5))" }}
               >
                 <DotLottieReact
                   src="/payment-asset.lottie"
@@ -169,7 +179,7 @@ export function PayLinkFab() {
         {/* Hover label (peer must follow the button in the DOM) + first-mount peek */}
         <span
           className={cn(
-            "pointer-events-none absolute right-full top-1/2 mr-3 -translate-y-1/2 whitespace-nowrap rounded-full border border-border bg-card px-3 py-1.5 text-xs font-medium shadow-md transition-all duration-300",
+            "pointer-events-none absolute right-full top-1/2 mr-3 -translate-y-1/2 whitespace-nowrap rounded-full border border-[#23262E] bg-[#0E1014] px-3 py-1.5 text-xs font-medium text-[#C7CBD2] shadow-md transition-all duration-300",
             "peer-hover:opacity-100 peer-hover:translate-x-0",
             !open && hint ? "opacity-100 translate-x-0" : "opacity-0 translate-x-1"
           )}

--- a/SPECTER-web/src/components/features/pay/RequestPaymentDrawer.tsx
+++ b/SPECTER-web/src/components/features/pay/RequestPaymentDrawer.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Download, Save, Share2 } from "lucide-react";
+import { Copy, Download, Save, Share2 } from "lucide-react";
 import {
   Sheet,
   SheetContent,
@@ -17,7 +17,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/base/select";
-import { CopyButton } from "@/components/ui/specialized/copy-button";
 import { QrCode, downloadQrPng } from "@/components/ui/specialized/qr-code";
 import { buildPayUrl, sanitizeAmountInput, type PayLinkParams } from "@/lib/payLink";
 import { addSavedRequest } from "@/lib/savedRequests";
@@ -27,7 +26,17 @@ import {
   type TxChain,
 } from "@/lib/blockchain/sendChains";
 import { analytics, type AnalyticsChain } from "@/lib/analytics";
+import { cn } from "@/lib/utils";
 import { toast } from "sonner";
+
+/* Dark Knight palette — kept in sync with PayLinkCard so the request flow
+ * feels like the same sealed object. */
+const goldBtn =
+  "bg-[#F2C94C] text-[#0B0D10] hover:bg-[#E5BE43] focus-visible:ring-[#F2C94C] border-0";
+const ghostBtn =
+  "border border-[#2A2E37] bg-transparent text-[#C7CBD2] hover:bg-[#15181E] hover:text-white";
+const fieldCls =
+  "border-[#23262E] bg-[#111317] text-[#EDEEF0] placeholder:text-[#5B616B] focus-visible:ring-[#F2C94C]/60";
 
 function toAnalyticsChain(chain: TxChain): AnalyticsChain {
   if (chain === "sui") return "sui";
@@ -87,37 +96,45 @@ export function RequestPaymentDrawer({
     }
   }
 
+  const canShare = typeof navigator !== "undefined" && "share" in navigator;
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="w-full sm:max-w-md overflow-y-auto">
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-md overflow-y-auto border-[#1E222A] bg-[#0B0D10] text-[#EDEEF0]"
+      >
+        {/* Bat-signal beam — the single gold note carried over from the pay card. */}
+        <div className="-mx-6 -mt-6 mb-6 h-px bg-gradient-to-r from-transparent via-[#F2C94C]/70 to-transparent" />
         <SheetHeader>
-          <SheetTitle>Request a payment</SheetTitle>
-          <SheetDescription className="sr-only">
-            Create a shareable payment request link and QR.
+          <SheetTitle className="text-[#F4F5F7]">Request a payment</SheetTitle>
+          <SheetDescription className="text-[#878C96]">
+            Set an amount and chain, then share the link or QR.
           </SheetDescription>
         </SheetHeader>
 
         <div className="mt-6 space-y-5">
           <div className="space-y-1.5">
-            <Label htmlFor="req-amount">Amount ({symbol})</Label>
+            <Label htmlFor="req-amount" className="text-[#878C96]">Amount ({symbol})</Label>
             <Input
               id="req-amount"
               inputMode="decimal"
               value={amount}
               onChange={(e) => setAmount(sanitizeAmountInput(e.target.value))}
               placeholder="0.00"
+              className={fieldCls}
             />
           </div>
 
           <div className="space-y-1.5">
-            <Label>Chain</Label>
+            <Label className="text-[#878C96]">Chain</Label>
             <Select value={chain} onValueChange={(v) => setChain(v as TxChain)}>
-              <SelectTrigger>
+              <SelectTrigger className={fieldCls}>
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent>
+              <SelectContent className="border-[#23262E] bg-[#0E1014] text-[#EDEEF0]">
                 {chains.map((c) => (
-                  <SelectItem key={c} value={c}>
+                  <SelectItem key={c} value={c} className="focus:bg-[#15181E] focus:text-white">
                     {getSendChainConfig(c).label} ({getSendChainConfig(c).currencySymbol})
                   </SelectItem>
                 ))}
@@ -126,54 +143,63 @@ export function RequestPaymentDrawer({
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="req-label">Label (optional)</Label>
+            <Label htmlFor="req-label" className="text-[#878C96]">Label (optional)</Label>
             <Input
               id="req-label"
               value={label}
               maxLength={80}
               onChange={(e) => setLabel(e.target.value)}
               placeholder="Invoice #204"
+              className={fieldCls}
             />
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="req-memo">Note to payer (optional)</Label>
+            <Label htmlFor="req-memo" className="text-[#878C96]">Note to payer (optional)</Label>
             <Input
               id="req-memo"
               value={memo}
               maxLength={140}
               onChange={(e) => setMemo(e.target.value)}
               placeholder="Design work, March"
+              className={fieldCls}
             />
           </div>
 
           {/* Live shareable card */}
-          <div
-            className="rounded-xl border border-border bg-card p-5 flex flex-col items-center gap-3"
-          >
-            <p className="text-xs text-muted-foreground">Pay request</p>
-            <p className="text-lg font-semibold">
-              {amount ? `${amount} ${symbol}` : "Any amount"}{" "}
-              <span className="text-muted-foreground font-normal">to {recipient}</span>
-            </p>
-            {label && <p className="text-sm">{label}</p>}
-            <QrCode value={url} size={160} />
-            <p className="font-mono text-[10px] text-muted-foreground break-all text-center">
-              {url}
-            </p>
+          <div className="overflow-hidden rounded-xl border border-[#1E222A] bg-[#0E1014]">
+            <div className="h-px w-full bg-gradient-to-r from-transparent via-[#F2C94C]/60 to-transparent" />
+            <div className="flex flex-col items-center gap-3 p-5">
+              <p className="text-[10px] uppercase tracking-[0.12em] text-[#878C96]">Pay request</p>
+              <p className="text-center text-lg font-semibold text-[#F4F5F7]">
+                {amount ? (
+                  <>
+                    {amount} <span className="text-[#F2C94C]">{symbol}</span>
+                  </>
+                ) : (
+                  "Any amount"
+                )}{" "}
+                <span className="font-normal text-[#878C96]">to {recipient}</span>
+              </p>
+              {label && <p className="text-sm text-[#C7CBD2]">{label}</p>}
+              <div className="rounded-lg bg-white p-2.5">
+                <QrCode value={url} size={148} />
+              </div>
+              <p className="break-all text-center font-mono text-[10px] text-[#5B616B]">{url}</p>
+            </div>
           </div>
 
-          <div className="flex flex-wrap gap-2">
-            <Button onClick={handleCreateAndCopy} className="flex-1 min-w-[8rem]">
-              Copy request link
-            </Button>
-            <CopyButton
-              text={url}
-              onCopied={() => analytics.payLinkCopied("drawer")}
-              showLabel={false}
-            />
+          {/* Primary: one unambiguous copy action (the standalone copy icon was a
+              duplicate of this button, so it's gone). */}
+          <Button onClick={handleCreateAndCopy} className={cn("w-full", goldBtn)}>
+            <Copy className="h-4 w-4 mr-1.5" /> Copy request link
+          </Button>
+
+          {/* Secondary: equal-width row so QR / Save / Share never wrap unevenly. */}
+          <div className={cn("grid gap-2", canShare ? "grid-cols-3" : "grid-cols-2")}>
             <Button
-              variant="outline"
+              size="sm"
+              className={ghostBtn}
               onClick={() => {
                 analytics.payLinkQrDownloaded("drawer");
                 downloadQrPng(url, `specter-request-${recipient}`);
@@ -181,12 +207,13 @@ export function RequestPaymentDrawer({
             >
               <Download className="h-4 w-4 mr-1.5" /> QR
             </Button>
-            <Button variant="outline" onClick={handleSave}>
+            <Button size="sm" className={ghostBtn} onClick={handleSave}>
               <Save className="h-4 w-4 mr-1.5" /> Save
             </Button>
-            {typeof navigator !== "undefined" && "share" in navigator && (
+            {canShare && (
               <Button
-                variant="ghost"
+                size="sm"
+                className={ghostBtn}
                 onClick={() => {
                   analytics.payLinkShared("drawer");
                   navigator.share?.({ title: "Pay request", url });

--- a/SPECTER-web/src/lib/myPayNames.ts
+++ b/SPECTER-web/src/lib/myPayNames.ts
@@ -1,0 +1,44 @@
+/**
+ * Local history of the *receiver's own* registered names entered in the
+ * pay-link card. Kept separate from `recentRecipients` (people you pay) so the
+ * two suggestion lists never bleed into each other. Mirrors the same
+ * localStorage shape used across the Send section.
+ */
+const STORAGE_KEY = "specter_my_pay_names";
+const MAX_ENTRIES = 5;
+
+export interface MyPayName {
+  name: string;
+  usedAt: number;
+}
+
+export function getMyPayNames(): MyPayName[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function addMyPayName(name: string): void {
+  const normalized = name.trim().toLowerCase();
+  if (!normalized) return;
+  try {
+    const existing = getMyPayNames().filter((r) => r.name !== normalized);
+    const updated = [{ name: normalized, usedAt: Date.now() }, ...existing].slice(0, MAX_ENTRIES);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  } catch {
+    // storage unavailable — silently skip
+  }
+}
+
+export function clearMyPayNames(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // storage unavailable — silently skip
+  }
+}


### PR DESCRIPTION
- Strip the floating orb to just the lottie (bare gold bat-signal halo, no purple gradient box); quiet graphite disc behind the close icon
- Reskin PayLinkCard and RequestPaymentDrawer in a graphite + signal-gold palette with a gold beam accent; declutter the action rows
- RequestPaymentDrawer: drop the redundant copy icon, full-width gold Copy primary, equal-width QR/Save/Share row, visible helper text
- Remember registered names locally (specter_my_pay_names) and surface them as inline suggestions in the pay-link card