### PR TITLE
Implement protocol v2 with secp256k1 spending key and stealth tweak

### DIFF
--- a/specter/Cargo.lock
+++ b/specter/Cargo.lock
@@ -4507,6 +4507,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "hex",
+ "k256",
  "proptest",
  "serde",
  "serde_json",

--- a/specter/specter-api/src/dto.rs
+++ b/specter/specter-api/src/dto.rs
@@ -12,16 +12,19 @@ use uuid::Uuid;
 /// stable view tag.
 #[derive(Debug, Serialize)]
 pub struct GenerateKeysResponse {
-    /// Spending public key (hex)
-    pub spending_pk: String,
-    /// Spending secret key (hex) - HANDLE WITH CARE
+    /// secp256k1 spending public key (33-byte compressed, hex)
+    pub spending_pub: String,
+    /// secp256k1 spending secret key (32 bytes, hex) - HANDLE WITH CARE.
+    /// This controls all funds; generate client-side in production.
     pub spending_sk: String,
-    /// Viewing public key (hex)
+    /// ML-KEM viewing public key (hex)
     pub viewing_pk: String,
-    /// Viewing secret key (hex) - HANDLE WITH CARE
+    /// ML-KEM viewing secret key (hex) - HANDLE WITH CARE
     pub viewing_sk: String,
     /// Meta-address (hex-encoded, for ENS storage)
     pub meta_address: String,
+    /// Protocol version of the generated keys (currently 2).
+    pub protocol_version: u8,
 }
 
 /// Request to create a stealth payment.
@@ -55,15 +58,18 @@ pub struct CreateStealthResponse {
     pub announcement: AnnouncementDto,
 }
 
-/// Request to scan for payments.
+/// Request to scan for payments (view-only).
+///
+/// Deliberately does NOT accept the spending secret key. Detection needs only
+/// the viewing secret key and the spending *public* key; the per-payment
+/// `shared_secret` is returned so the client can derive spend keys locally with
+/// its own secret spending key (which must never be sent to a server).
 #[derive(Debug, Deserialize)]
 pub struct ScanRequest {
-    /// Viewing secret key (hex)
+    /// ML-KEM viewing secret key (hex)
     pub viewing_sk: String,
-    /// Spending public key (hex)
-    pub spending_pk: String,
-    /// Spending secret key (hex)
-    pub spending_sk: String,
+    /// secp256k1 spending public key (33-byte compressed, hex)
+    pub spending_pub: String,
     /// Optional: Only scan specific view tags
     pub view_tags: Option<Vec<u8>>,
     /// Optional: Scan from timestamp
@@ -82,16 +88,19 @@ pub struct ScanResponse {
 }
 
 /// A discovered payment.
+///
+/// Contains no private key. To spend, the client derives the spend key locally
+/// from `shared_secret` + its secret spending key (never sent to the server).
 #[derive(Debug, Serialize)]
 pub struct DiscoveryDto {
     /// Stealth Ethereum address (checksummed)
     pub stealth_address: String,
     /// Stealth Sui address
     pub stealth_sui_address: String,
-    /// Stealth private key (hex) - HANDLE WITH CARE
-    pub stealth_sk: String,
-    /// Ethereum-compatible private key (32 bytes, hex)
-    pub eth_private_key: String,
+    /// Per-payment ML-KEM shared secret (hex). Feed this plus your secret
+    /// spending key into client-side `derive_stealth_keys` to obtain the spend
+    /// key. Knowing it alone does NOT allow spending.
+    pub shared_secret: String,
     /// Announcement ID
     pub announcement_id: u64,
     /// Timestamp
@@ -140,8 +149,8 @@ pub struct ResolveEnsResponse {
     pub ens_name: String,
     /// Meta-address (hex)
     pub meta_address: String,
-    /// Spending public key (hex)
-    pub spending_pk: String,
+    /// secp256k1 spending public key (hex)
+    pub spending_pub: String,
     /// Viewing public key (hex)
     pub viewing_pk: String,
     /// IPFS CID where meta-address is stored
@@ -155,8 +164,8 @@ pub struct ResolveSuinsResponse {
     pub suins_name: String,
     /// Meta-address (hex)
     pub meta_address: String,
-    /// Spending public key (hex)
-    pub spending_pk: String,
+    /// secp256k1 spending public key (hex)
+    pub spending_pub: String,
     /// Viewing public key (hex)
     pub viewing_pk: String,
     /// IPFS CID where meta-address is stored

--- a/specter/specter-api/src/handlers.rs
+++ b/specter/specter-api/src/handlers.rs
@@ -16,7 +16,7 @@ use tracing::{debug, info, warn};
 
 use specter_core::traits::AnnouncementRegistry;
 use specter_core::types::{Announcement, KyberPublicKey, MetaAddress};
-use specter_crypto::generate_keypair;
+use specter_crypto::{generate_keypair, generate_spending_keypair};
 use specter_stealth::create_stealth_payment;
 
 use crate::dto::*;
@@ -32,23 +32,24 @@ type Result<T> = std::result::Result<T, ApiError>;
 pub async fn generate_keys(
     State(_state): State<Arc<AppState>>,
 ) -> Result<Json<GenerateKeysResponse>> {
-    let spending = generate_keypair();
+    let spending = generate_spending_keypair();
     let viewing = generate_keypair();
 
     let meta = MetaAddress::new(
-        KyberPublicKey::from_array(*spending.public.as_array()),
+        spending.public.clone(),
         KyberPublicKey::from_array(*viewing.public.as_array()),
     );
 
     let response = GenerateKeysResponse {
-        spending_pk: hex::encode(spending.public.as_bytes()),
+        spending_pub: spending.public.to_hex(),
         spending_sk: hex::encode(spending.secret.as_bytes()),
         viewing_pk: hex::encode(viewing.public.as_bytes()),
         viewing_sk: hex::encode(viewing.secret.as_bytes()),
         meta_address: meta.to_hex(),
+        protocol_version: specter_core::constants::PROTOCOL_VERSION,
     };
 
-    info!("Generated new SPECTER keys");
+    info!("Generated new SPECTER keys (protocol v2, secp256k1 spending)");
     Ok(Json(response))
 }
 
@@ -103,8 +104,7 @@ pub async fn scan_payments(
     let start = Instant::now();
 
     let viewing_sk = hex::decode(strip_hex_prefix(&req.viewing_sk))?;
-    let spending_pk = hex::decode(strip_hex_prefix(&req.spending_pk))?;
-    let spending_sk = hex::decode(strip_hex_prefix(&req.spending_sk))?;
+    let spending_pub = hex::decode(strip_hex_prefix(&req.spending_pub))?;
 
     let announcements = if let Some(tags) = &req.view_tags {
         let mut all = Vec::new();
@@ -130,8 +130,7 @@ pub async fn scan_payments(
     let (discoveries, scan_stats) = specter_stealth::discovery::scan_with_context_and_stats(
         &announcements,
         &viewing_sk,
-        &spending_pk,
-        &spending_sk,
+        &spending_pub,
     );
 
     let elapsed = start.elapsed();
@@ -140,10 +139,9 @@ pub async fn scan_payments(
     let discovery_dtos: Vec<DiscoveryDto> = discoveries
         .into_iter()
         .map(|d| DiscoveryDto {
-            stealth_address: d.keys.address.to_checksum_string(),
-            stealth_sui_address: d.keys.sui_address.to_hex_string(),
-            stealth_sk: hex::encode(d.keys.private_key.as_bytes()),
-            eth_private_key: hex::encode(d.keys.private_key.to_eth_private_key()),
+            stealth_address: d.payment.address.to_checksum_string(),
+            stealth_sui_address: d.payment.sui_address.to_hex_string(),
+            shared_secret: hex::encode(d.payment.shared_secret),
             announcement_id: d.announcement.id,
             timestamp: d.announcement.timestamp,
             tx_hash: d.announcement.tx_hash.clone(),
@@ -196,7 +194,7 @@ pub async fn resolve_ens(
     Ok(Json(ResolveEnsResponse {
         ens_name: result.ens_name,
         meta_address: result.meta_address.to_hex(),
-        spending_pk: result.meta_address.spending_pk.to_hex(),
+        spending_pub: result.meta_address.spending_pub.to_hex(),
         viewing_pk: result.meta_address.viewing_pk.to_hex(),
         ipfs_cid: if result.ipfs_cid.is_empty() {
             None
@@ -225,7 +223,7 @@ pub async fn resolve_suins(
     Ok(Json(ResolveSuinsResponse {
         suins_name: result.suins_name,
         meta_address: result.meta_address.to_hex(),
-        spending_pk: result.meta_address.spending_pk.to_hex(),
+        spending_pub: result.meta_address.spending_pub.to_hex(),
         viewing_pk: result.meta_address.viewing_pk.to_hex(),
         ipfs_cid: if result.ipfs_cid.is_empty() {
             None

--- a/specter/specter-cli/src/bin/e2e_flow.rs
+++ b/specter/specter-cli/src/bin/e2e_flow.rs
@@ -38,7 +38,8 @@ use specter_core::traits::AnnouncementRegistry;
 use specter_core::types::{AnnouncementBuilder, AnnouncementMetadata, MetaAddress};
 use specter_crypto::{
     derive::derive_stealth_address, encapsulate, encrypt_announcement_metadata, generate_keypair,
-    hash::keccak256, metadata::ENCRYPTED_METADATA_SIZE, view_tag::compute_view_tag, DbKeys,
+    generate_spending_keypair, hash::keccak256, metadata::ENCRYPTED_METADATA_SIZE,
+    view_tag::compute_view_tag, DbKeys,
 };
 use specter_registry::turso::TursoRegistry;
 use specter_stealth::discovery::scan_with_context_and_stats;
@@ -164,9 +165,10 @@ async fn main() -> Result<()> {
         "Generating ephemeral recipient SPECTER keys (ML-KEM-768)",
     );
 
-    // Raw ML-KEM keypairs (spending + viewing) so the canonical recipient scan in
-    // step 9 can run with the recipient's secret keys — exactly as a wallet/SDK does.
-    let spending = generate_keypair();
+    // secp256k1 spending keypair + ML-KEM viewing keypair (protocol v2), so the
+    // canonical recipient scan in step 9 can run with the recipient's secret keys
+    // — exactly as a wallet/SDK does.
+    let spending = generate_spending_keypair();
     let viewing = generate_keypair();
     let meta = MetaAddress::new(spending.public.clone(), viewing.public.clone());
 
@@ -190,8 +192,8 @@ async fn main() -> Result<()> {
 
     let view_tag = compute_view_tag(&shared_secret);
 
-    // derive_stealth_address(spending_pk_bytes, shared_secret) → EthAddress
-    let stealth_eth = derive_stealth_address(meta.spending_pk.as_bytes(), &shared_secret)
+    // derive_stealth_address(spending_pub_bytes, shared_secret) → EthAddress
+    let stealth_eth = derive_stealth_address(meta.spending_pub.as_bytes(), &shared_secret)
         .context("Stealth address derivation failed")?;
 
     let stealth_addr_hex = stealth_eth.to_checksum_string();
@@ -579,14 +581,11 @@ async fn main() -> Result<()> {
     // ciphertext, matches the view tag, decrypts metadata_blob, AND derives the
     // stealth keys — all in one pass (no manual decrypt, no separate discovery).
     let viewing_sk = viewing.secret.as_bytes().to_vec();
-    let spending_pk = spending.public.as_bytes().to_vec();
+    let spending_pub = spending.public.as_bytes().to_vec();
     let spending_sk = spending.secret.as_bytes().to_vec();
-    let (discoveries, _scan_stats) = scan_with_context_and_stats(
-        std::slice::from_ref(found),
-        &viewing_sk,
-        &spending_pk,
-        &spending_sk,
-    );
+    // Detection is view-only (viewing_sk + spending_pub).
+    let (discoveries, _scan_stats) =
+        scan_with_context_and_stats(std::slice::from_ref(found), &viewing_sk, &spending_pub);
 
     match discoveries.first() {
         Some(d) => {
@@ -606,11 +605,31 @@ async fn main() -> Result<()> {
                 fail_msg("canonical scan: source_chain_id not recovered from blob");
                 errs += 1;
             }
-            let recovered = d.keys.address.to_checksum_string();
+            let recovered = d.payment.address.to_checksum_string();
             if recovered.eq_ignore_ascii_case(&stealth_addr_hex) {
                 ok(&format!(
                     "canonical scan:     stealth address recovered {recovered}"
                 ));
+
+                // Spend step: derive the private key locally with the secret
+                // spending key and confirm it controls the stealth address.
+                match specter_stealth::discovery::derive_spend_keys(
+                    &spending_pub,
+                    &spending_sk,
+                    &d.payment.shared_secret,
+                ) {
+                    Ok(keys) if keys.address == d.payment.address => {
+                        ok("spend derivation:   eth private key controls stealth address")
+                    }
+                    Ok(_) => {
+                        fail_msg("spend derivation: derived address mismatch");
+                        errs += 1;
+                    }
+                    Err(e) => {
+                        fail_msg(&format!("spend derivation failed: {e}"));
+                        errs += 1;
+                    }
+                }
             } else {
                 fail_msg(&format!(
                     "canonical scan: expected {stealth_addr_hex}, got {recovered}"

--- a/specter/specter-cli/src/main.rs
+++ b/specter/specter-cli/src/main.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 use specter_api::{ApiConfig, ApiServer};
 use specter_core::traits::AnnouncementRegistry;
 use specter_core::types::{Announcement, KyberPublicKey, MetaAddress};
-use specter_crypto::generate_keypair;
+use specter_crypto::{generate_keypair, generate_spending_keypair};
 use specter_ens::{ResolverConfig, SpecterResolver};
 use specter_registry::MemoryRegistry;
 use specter_stealth::create_stealth_payment;
@@ -117,22 +117,23 @@ async fn main() -> Result<()> {
 async fn cmd_generate(output: Option<PathBuf>) -> Result<()> {
     println!("{}", "🔑 Generating SPECTER keys...".cyan().bold());
 
-    let spending = generate_keypair();
+    let spending = generate_spending_keypair();
     let viewing = generate_keypair();
 
     let meta = MetaAddress::new(
-        KyberPublicKey::from_array(*spending.public.as_array()),
+        spending.public.clone(),
         KyberPublicKey::from_array(*viewing.public.as_array()),
     );
 
     // No `view_tag` field: SPECTER view tags are per-payment (derived from the
     // Kyber shared secret) and have no meaning at the wallet level.
     let keys_json = serde_json::json!({
-        "spending_pk": hex::encode(spending.public.as_bytes()),
+        "spending_pub": spending.public.to_hex(),
         "spending_sk": hex::encode(spending.secret.as_bytes()),
         "viewing_pk": hex::encode(viewing.public.as_bytes()),
         "viewing_sk": hex::encode(viewing.secret.as_bytes()),
         "meta_address": meta.to_hex(),
+        "protocol_version": specter_core::constants::PROTOCOL_VERSION,
     });
 
     if let Some(path) = output {
@@ -178,7 +179,7 @@ async fn cmd_resolve(name: &str, rpc_url: Option<String>) -> Result<()> {
     println!(
         "   {} {}...",
         "Spending PK:".dimmed(),
-        &meta.spending_pk.to_hex()[..32]
+        &meta.spending_pub.to_hex()[..32]
     );
     println!(
         "   {} {}...",
@@ -274,15 +275,10 @@ async fn cmd_scan(keys_path: &PathBuf, registry_path: Option<&std::path::Path>) 
             .as_str()
             .context("Missing viewing_sk")?,
     )?;
-    let spending_pk = hex::decode(
-        keys_json["spending_pk"]
+    let spending_pub = hex::decode(
+        keys_json["spending_pub"]
             .as_str()
-            .context("Missing spending_pk")?,
-    )?;
-    let spending_sk = hex::decode(
-        keys_json["spending_sk"]
-            .as_str()
-            .context("Missing spending_sk")?,
+            .context("Missing spending_pub (regenerate keys — v1 files are unsupported)")?,
     )?;
 
     // Load announcements
@@ -315,13 +311,9 @@ async fn cmd_scan(keys_path: &PathBuf, registry_path: Option<&std::path::Path>) 
             .progress_chars("#>-"),
     );
 
-    // Scan announcements
-    let discoveries = specter_stealth::discovery::scan_announcements(
-        &announcements,
-        &viewing_sk,
-        &spending_pk,
-        &spending_sk,
-    );
+    // Scan announcements (view-only: viewing_sk + spending_pub).
+    let discoveries =
+        specter_stealth::discovery::scan_announcements(&announcements, &viewing_sk, &spending_pub);
 
     pb.finish_with_message("done");
 
@@ -329,11 +321,11 @@ async fn cmd_scan(keys_path: &PathBuf, registry_path: Option<&std::path::Path>) 
         println!("\n{}", "No payments found.".yellow());
     } else {
         println!("\n{} {} payment(s) found:", "✅".green(), discoveries.len());
-        for (idx, keys) in &discoveries {
+        for (idx, payment) in &discoveries {
             println!(
                 "   {} {}",
                 "Address:".green(),
-                keys.address.to_checksum_string()
+                payment.address.to_checksum_string()
             );
             println!("      Announcement #{}", idx); // Todo: Use actual ID if available
         }
@@ -374,7 +366,7 @@ async fn cmd_bench(count: usize) -> Result<()> {
     // Generate keys
     println!("\n{}", "1. Generating keys...".dimmed());
     let start = std::time::Instant::now();
-    let spending = generate_keypair();
+    let spending = generate_spending_keypair();
     let viewing = generate_keypair();
     println!("   ✓ Key generation: {:?}", start.elapsed());
 
@@ -382,7 +374,7 @@ async fn cmd_bench(count: usize) -> Result<()> {
     println!("\n{}", "2. Creating announcements...".dimmed());
     let registry = MemoryRegistry::new();
     let meta = MetaAddress::new(
-        KyberPublicKey::from_array(*spending.public.as_array()),
+        spending.public.clone(),
         KyberPublicKey::from_array(*viewing.public.as_array()),
     );
 
@@ -422,7 +414,6 @@ async fn cmd_bench(count: usize) -> Result<()> {
         &announcements,
         viewing.secret.as_bytes(),
         spending.public.as_bytes(),
-        spending.secret.as_bytes(),
     );
     let scan_time = start.elapsed();
 

--- a/specter/specter-core/Cargo.toml
+++ b/specter/specter-core/Cargo.toml
@@ -18,6 +18,9 @@ thiserror = { workspace = true }
 # Security
 zeroize = { workspace = true }
 
+# secp256k1 spending key (protocol v2): validates compressed public keys on-curve.
+k256 = { version = "0.13", features = ["ecdsa"] }
+
 # Async
 async-trait = { workspace = true }
 

--- a/specter/specter-core/src/constants.rs
+++ b/specter/specter-core/src/constants.rs
@@ -23,6 +23,23 @@ pub const KYBER_CIPHERTEXT_SIZE: usize = 1088;
 pub const KYBER_SHARED_SECRET_SIZE: usize = 32;
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// SECP256K1 SIZES (SPENDING KEY, PROTOCOL v2)
+// ═══════════════════════════════════════════════════════════════════════════════
+//
+// As of protocol v2 the *spending* key is a secp256k1 keypair (not ML-KEM). This
+// is what makes stealth addresses genuinely one-way: the sender can derive the
+// stealth *address* from the public spending key, but only the holder of the
+// secret spending scalar can derive the spend key. See `specter-crypto::derive`.
+//
+// The *viewing* key remains ML-KEM-768 so payment discovery stays post-quantum.
+
+/// Size of a compressed secp256k1 public key in bytes (0x02/0x03 prefix + X).
+pub const SECP256K1_PUBLIC_KEY_SIZE: usize = 33;
+
+/// Size of a secp256k1 secret scalar in bytes.
+pub const SECP256K1_SECRET_KEY_SIZE: usize = 32;
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // VIEW TAG CONSTANTS
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -74,6 +91,12 @@ pub const DOMAIN_ETH_ADDRESS: &[u8] = b"SPECTER_ETH_ADDRESS_V1";
 /// Domain separator for Ethereum secp256k1 key derivation (stealth address = eth address).
 pub const DOMAIN_ETH_KEY: &[u8] = b"SPECTER_ETH_KEY_V1";
 
+/// Domain separator for the v2 stealth tweak scalar `t = H(shared_secret)`.
+///
+/// The tweak is the additive secp256k1 scalar that shifts the recipient's
+/// spending key to a one-time stealth key: `P = B + t·G`, `p = b + t (mod n)`.
+pub const DOMAIN_STEALTH_TWEAK: &[u8] = b"SPECTER_STEALTH_TWEAK_V2";
+
 /// Domain separator for metadata encryption key derivation (AES-256-GCM key).
 pub const DOMAIN_META_ENC_KEY: &[u8] = b"SPECTER_META_ENC_KEY_V1";
 
@@ -96,11 +119,15 @@ pub const DOMAIN_DB_IP_HASH: &[u8] = b"SPECTER_DB_IP_HASH_V1";
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /// Current protocol version.
-/// Increment when making breaking changes to serialization formats.
-pub const PROTOCOL_VERSION: u8 = 1;
+///
+/// v2 (breaking): the spending key is secp256k1 and stealth keys use additive
+/// tweak derivation (`P = B + t·G`). v1 meta-addresses and v1 stealth payments
+/// are NOT compatible and are rejected — v1 stealth keys were derivable by the
+/// sender and must be treated as compromised.
+pub const PROTOCOL_VERSION: u8 = 2;
 
-/// Minimum supported protocol version for backward compatibility.
-pub const MIN_PROTOCOL_VERSION: u8 = 1;
+/// Minimum supported protocol version. v1 is rejected everywhere.
+pub const MIN_PROTOCOL_VERSION: u8 = 2;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // ETHEREUM CONSTANTS
@@ -156,9 +183,10 @@ pub const SUI_TESTNET_RPC_URL: &str = "https://fullnode.testnet.sui.io:443";
 // SERIALIZATION CONSTANTS
 // ═══════════════════════════════════════════════════════════════════════════════
 
-/// Size of serialized MetaAddress (version + spending_pk + viewing_pk).
-/// 1 + 1184 + 1184 = 2369 bytes
-pub const META_ADDRESS_SERIALIZED_SIZE: usize = 1 + KYBER_PUBLIC_KEY_SIZE + KYBER_PUBLIC_KEY_SIZE;
+/// Size of serialized MetaAddress v2 (version + secp256k1 spending_pub + ML-KEM viewing_pk).
+/// 1 + 33 + 1184 = 1218 bytes
+pub const META_ADDRESS_SERIALIZED_SIZE: usize =
+    1 + SECP256K1_PUBLIC_KEY_SIZE + KYBER_PUBLIC_KEY_SIZE;
 
 /// Size of serialized Announcement (ephemeral_key + view_tag + timestamp).
 /// 1088 + 1 + 8 = 1097 bytes (plus optional fields)
@@ -196,8 +224,8 @@ mod tests {
 
     #[test]
     fn test_meta_address_size() {
-        // version (1) + spending_pk (1184) + viewing_pk (1184)
-        assert_eq!(META_ADDRESS_SERIALIZED_SIZE, 2369);
+        // v2: version (1) + secp256k1 spending_pub (33) + ML-KEM viewing_pk (1184)
+        assert_eq!(META_ADDRESS_SERIALIZED_SIZE, 1218);
     }
 
     #[test]
@@ -210,6 +238,7 @@ mod tests {
             DOMAIN_SPENDING_SEED,
             DOMAIN_ETH_ADDRESS,
             DOMAIN_ETH_KEY,
+            DOMAIN_STEALTH_TWEAK,
             DOMAIN_META_ENC_KEY,
             DOMAIN_META_ENC_NONCE,
             DOMAIN_DB_HMAC_KEY,

--- a/specter/specter-core/src/types/address.rs
+++ b/specter/specter-core/src/types/address.rs
@@ -5,8 +5,11 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::KyberPublicKey;
-use crate::constants::{ETH_ADDRESS_SIZE, PROTOCOL_VERSION, SUI_ADDRESS_SIZE};
+use super::{KyberPublicKey, Secp256k1PublicKey};
+use crate::constants::{
+    ETH_ADDRESS_SIZE, KYBER_PUBLIC_KEY_SIZE, META_ADDRESS_SERIALIZED_SIZE, PROTOCOL_VERSION,
+    SECP256K1_PUBLIC_KEY_SIZE, SUI_ADDRESS_SIZE,
+};
 use crate::error::{Result, SpecterError};
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -18,28 +21,31 @@ use crate::error::{Result, SpecterError};
 /// This is what gets stored on IPFS and linked from ENS text records.
 /// Senders use this to create stealth addresses.
 ///
-/// # Structure
-/// - `version`: Protocol version for forward compatibility
-/// - `spending_pk`: Public key for spending (stealth address derivation)
-/// - `viewing_pk`: Public key for viewing (allows third-party auditing)
+/// # Structure (protocol v2)
+/// - `version`: Protocol version (must be 2)
+/// - `spending_pub`: secp256k1 spending public key (33 bytes) — used to derive
+///   the stealth *address*. Only the holder of the matching secret scalar can
+///   derive the stealth spend key.
+/// - `viewing_pk`: ML-KEM-768 viewing public key (1184 bytes) — used for
+///   post-quantum payment discovery / third-party auditing.
 ///
 /// # Example
 /// ```ignore
 /// use specter_core::MetaAddress;
 ///
 /// // Create meta-address from generated keys
-/// let meta = MetaAddress::new(spending_pk, viewing_pk);
+/// let meta = MetaAddress::new(spending_pub, viewing_pk);
 ///
 /// // Serialize for ENS storage
-/// let encoded = meta.to_compact_string();
+/// let encoded = meta.to_hex();
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MetaAddress {
-    /// Protocol version (for forward compatibility)
+    /// Protocol version (must be 2)
     pub version: u8,
-    /// Spending public key - used to derive stealth addresses
-    pub spending_pk: KyberPublicKey,
-    /// Viewing public key - used for scanning announcements
+    /// secp256k1 spending public key - used to derive stealth addresses
+    pub spending_pub: Secp256k1PublicKey,
+    /// ML-KEM viewing public key - used for scanning announcements
     pub viewing_pk: KyberPublicKey,
     /// Optional metadata
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -62,10 +68,10 @@ pub struct MetaAddressMetadata {
 
 impl MetaAddress {
     /// Creates a new meta-address with the current protocol version.
-    pub fn new(spending_pk: KyberPublicKey, viewing_pk: KyberPublicKey) -> Self {
+    pub fn new(spending_pub: Secp256k1PublicKey, viewing_pk: KyberPublicKey) -> Self {
         Self {
             version: PROTOCOL_VERSION,
-            spending_pk,
+            spending_pub,
             viewing_pk,
             metadata: None,
         }
@@ -73,13 +79,13 @@ impl MetaAddress {
 
     /// Creates a meta-address with metadata.
     pub fn with_metadata(
-        spending_pk: KyberPublicKey,
+        spending_pub: Secp256k1PublicKey,
         viewing_pk: KyberPublicKey,
         metadata: MetaAddressMetadata,
     ) -> Self {
         Self {
             version: PROTOCOL_VERSION,
-            spending_pk,
+            spending_pub,
             viewing_pk,
             metadata: Some(metadata),
         }
@@ -87,14 +93,17 @@ impl MetaAddress {
 
     /// Validates the meta-address structure.
     pub fn validate(&self) -> Result<()> {
-        if self.version == 0 {
-            return Err(SpecterError::InvalidMetaAddress(
-                "version cannot be 0".into(),
-            ));
+        if self.version != PROTOCOL_VERSION {
+            return Err(SpecterError::InvalidMetaAddress(format!(
+                "unsupported protocol version {} (expected {}); v1 meta-addresses are \
+                 insecure and no longer accepted — regenerate keys",
+                self.version, PROTOCOL_VERSION
+            )));
         }
 
-        // Check for obviously invalid keys (all zeros)
-        if self.spending_pk.as_bytes().iter().all(|&b| b == 0) {
+        // Reject an on-curve-but-uninitialised (all-zero) spending key. A real
+        // secp256k1 point is validated at construction time in Secp256k1PublicKey.
+        if self.spending_pub.as_bytes().iter().all(|&b| b == 0) {
             return Err(SpecterError::InvalidMetaAddress(
                 "spending key is all zeros".into(),
             ));
@@ -111,31 +120,34 @@ impl MetaAddress {
 
     /// Serializes to compact binary format.
     ///
-    /// Format: version (1) || spending_pk (1184) || viewing_pk (1184)
+    /// Format (v2): version (1) || spending_pub (33) || viewing_pk (1184)
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(1 + 1184 + 1184);
+        let mut bytes = Vec::with_capacity(META_ADDRESS_SERIALIZED_SIZE);
         bytes.push(self.version);
-        bytes.extend_from_slice(self.spending_pk.as_bytes());
+        bytes.extend_from_slice(self.spending_pub.as_bytes());
         bytes.extend_from_slice(self.viewing_pk.as_bytes());
         bytes
     }
 
-    /// Deserializes from compact binary format.
+    /// Deserializes from compact binary format (v2 only).
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        if bytes.len() < 1 + 1184 + 1184 {
+        if bytes.len() < META_ADDRESS_SERIALIZED_SIZE {
             return Err(SpecterError::InvalidMetaAddress(format!(
-                "too short: {} bytes",
-                bytes.len()
+                "too short: {} bytes, expected {}",
+                bytes.len(),
+                META_ADDRESS_SERIALIZED_SIZE
             )));
         }
 
         let version = bytes[0];
-        let spending_pk = KyberPublicKey::from_bytes(&bytes[1..1185])?;
-        let viewing_pk = KyberPublicKey::from_bytes(&bytes[1185..2369])?;
+        let spending_end = 1 + SECP256K1_PUBLIC_KEY_SIZE;
+        let viewing_end = spending_end + KYBER_PUBLIC_KEY_SIZE;
+        let spending_pub = Secp256k1PublicKey::from_bytes(&bytes[1..spending_end])?;
+        let viewing_pk = KyberPublicKey::from_bytes(&bytes[spending_end..viewing_end])?;
 
         let meta = Self {
             version,
-            spending_pk,
+            spending_pub,
             viewing_pk,
             metadata: None,
         };
@@ -160,7 +172,7 @@ impl Default for MetaAddress {
     fn default() -> Self {
         Self {
             version: PROTOCOL_VERSION,
-            spending_pk: KyberPublicKey::default(),
+            spending_pub: Secp256k1PublicKey::default(),
             viewing_pk: KyberPublicKey::default(),
             metadata: None,
         }
@@ -394,56 +406,74 @@ mod tests {
     use super::*;
     use crate::constants::KYBER_PUBLIC_KEY_SIZE;
 
+    /// A deterministic, valid compressed secp256k1 public key for tests.
+    fn test_spending_pub(seed: u8) -> Secp256k1PublicKey {
+        let sk = k256::SecretKey::from_slice(&[seed; 32]).unwrap();
+        let compressed = sk.public_key().to_sec1_bytes();
+        Secp256k1PublicKey::from_bytes(&compressed).unwrap()
+    }
+
     #[test]
     fn test_meta_address_creation() {
-        let spending_pk = KyberPublicKey::from_array([1u8; KYBER_PUBLIC_KEY_SIZE]);
+        let spending_pub = test_spending_pub(1);
         let viewing_pk = KyberPublicKey::from_array([2u8; KYBER_PUBLIC_KEY_SIZE]);
 
-        let meta = MetaAddress::new(spending_pk.clone(), viewing_pk.clone());
+        let meta = MetaAddress::new(spending_pub.clone(), viewing_pk.clone());
         assert_eq!(meta.version, PROTOCOL_VERSION);
-        assert_eq!(meta.spending_pk, spending_pk);
+        assert_eq!(meta.spending_pub, spending_pub);
         assert_eq!(meta.viewing_pk, viewing_pk);
     }
 
     #[test]
     fn test_meta_address_bytes_roundtrip() {
-        let spending_pk = KyberPublicKey::from_array([0xAA; KYBER_PUBLIC_KEY_SIZE]);
+        let spending_pub = test_spending_pub(0xAA);
         let viewing_pk = KyberPublicKey::from_array([0xBB; KYBER_PUBLIC_KEY_SIZE]);
 
-        let meta = MetaAddress::new(spending_pk, viewing_pk);
+        let meta = MetaAddress::new(spending_pub, viewing_pk);
         let bytes = meta.to_bytes();
+        assert_eq!(bytes.len(), META_ADDRESS_SERIALIZED_SIZE);
         let meta2 = MetaAddress::from_bytes(&bytes).unwrap();
 
         assert_eq!(meta.version, meta2.version);
-        assert_eq!(meta.spending_pk, meta2.spending_pk);
+        assert_eq!(meta.spending_pub, meta2.spending_pub);
         assert_eq!(meta.viewing_pk, meta2.viewing_pk);
     }
 
     #[test]
     fn test_meta_address_hex_roundtrip() {
-        let spending_pk = KyberPublicKey::from_array([0x12; KYBER_PUBLIC_KEY_SIZE]);
+        let spending_pub = test_spending_pub(0x12);
         let viewing_pk = KyberPublicKey::from_array([0x34; KYBER_PUBLIC_KEY_SIZE]);
 
-        let meta = MetaAddress::new(spending_pk, viewing_pk);
+        let meta = MetaAddress::new(spending_pub, viewing_pk);
         let hex = meta.to_hex();
         let meta2 = MetaAddress::from_hex(&hex).unwrap();
 
-        assert_eq!(meta.spending_pk, meta2.spending_pk);
+        assert_eq!(meta.spending_pub, meta2.spending_pub);
     }
 
     #[test]
     fn test_meta_address_validation() {
         // Valid meta-address
         let valid = MetaAddress::new(
-            KyberPublicKey::from_array([1u8; KYBER_PUBLIC_KEY_SIZE]),
+            test_spending_pub(1),
             KyberPublicKey::from_array([2u8; KYBER_PUBLIC_KEY_SIZE]),
         );
         assert!(valid.validate().is_ok());
 
         // Invalid: zero spending key
         let mut invalid = valid.clone();
-        invalid.spending_pk = KyberPublicKey::default();
+        invalid.spending_pub = Secp256k1PublicKey::default();
         assert!(invalid.validate().is_err());
+    }
+
+    #[test]
+    fn test_meta_address_rejects_v1() {
+        let mut meta = MetaAddress::new(
+            test_spending_pub(7),
+            KyberPublicKey::from_array([3u8; KYBER_PUBLIC_KEY_SIZE]),
+        );
+        meta.version = 1;
+        assert!(meta.validate().is_err(), "v1 meta-address must be rejected");
     }
 
     #[test]

--- a/specter/specter-core/src/types/keys.rs
+++ b/specter/specter-core/src/types/keys.rs
@@ -11,7 +11,10 @@
 use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use crate::constants::{KYBER_PUBLIC_KEY_SIZE, KYBER_SECRET_KEY_SIZE};
+use crate::constants::{
+    KYBER_PUBLIC_KEY_SIZE, KYBER_SECRET_KEY_SIZE, SECP256K1_PUBLIC_KEY_SIZE,
+    SECP256K1_SECRET_KEY_SIZE,
+};
 use crate::error::{Result, SpecterError};
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -207,28 +210,201 @@ impl std::fmt::Debug for KeyPair {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// SECP256K1 SPENDING KEYS (PROTOCOL v2)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// A compressed secp256k1 public key (33 bytes) — the recipient's *spending*
+/// public key as published in a v2 meta-address.
+///
+/// The sender uses this to derive the stealth *address* (`P = B + t·G`). It is
+/// safe to share publicly and is validated to be a valid on-curve point.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Secp256k1PublicKey {
+    bytes: [u8; SECP256K1_PUBLIC_KEY_SIZE],
+}
+
+impl Secp256k1PublicKey {
+    /// Creates a public key from raw bytes, validating it is a canonical,
+    /// on-curve, compressed secp256k1 point.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() != SECP256K1_PUBLIC_KEY_SIZE {
+            return Err(SpecterError::InvalidKeySize {
+                expected: SECP256K1_PUBLIC_KEY_SIZE,
+                actual: bytes.len(),
+            });
+        }
+        // Reject garbage / off-curve / identity points at the boundary.
+        k256::PublicKey::from_sec1_bytes(bytes).map_err(|_| {
+            SpecterError::InvalidMetaAddress("spending key is not a valid secp256k1 point".into())
+        })?;
+        let mut arr = [0u8; SECP256K1_PUBLIC_KEY_SIZE];
+        arr.copy_from_slice(bytes);
+        Ok(Self { bytes: arr })
+    }
+
+    /// Creates a public key from a fixed-size array without curve validation.
+    ///
+    /// Prefer [`Secp256k1PublicKey::from_bytes`] for untrusted input.
+    pub fn from_array(bytes: [u8; SECP256K1_PUBLIC_KEY_SIZE]) -> Self {
+        Self { bytes }
+    }
+
+    /// Returns the raw compressed bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Returns the compressed bytes as a fixed-size array reference.
+    pub fn as_array(&self) -> &[u8; SECP256K1_PUBLIC_KEY_SIZE] {
+        &self.bytes
+    }
+
+    /// Returns the hex-encoded compressed public key (no `0x` prefix).
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.bytes)
+    }
+
+    /// Parses from a hex string (with or without `0x` prefix), validating the point.
+    pub fn from_hex(s: &str) -> Result<Self> {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        let bytes = hex::decode(s)?;
+        Self::from_bytes(&bytes)
+    }
+
+    /// Returns the underlying `k256::PublicKey`. Infallible because the bytes
+    /// were validated on construction (via `from_bytes`/`from_hex`).
+    pub fn to_k256(&self) -> Result<k256::PublicKey> {
+        k256::PublicKey::from_sec1_bytes(&self.bytes).map_err(|_| {
+            SpecterError::InvalidMetaAddress("spending key is not a valid secp256k1 point".into())
+        })
+    }
+}
+
+impl std::fmt::Debug for Secp256k1PublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Secp256k1PublicKey({})", self.to_hex())
+    }
+}
+
+impl Default for Secp256k1PublicKey {
+    fn default() -> Self {
+        Self {
+            bytes: [0u8; SECP256K1_PUBLIC_KEY_SIZE],
+        }
+    }
+}
+
+impl Serialize for Secp256k1PublicKey {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> std::result::Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for Secp256k1PublicKey {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> std::result::Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        Self::from_hex(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// A secp256k1 secret scalar (32 bytes) — the recipient's *spending* secret key.
+///
+/// This is the crown-jewel secret: it controls **every** stealth address the
+/// recipient will ever receive. It must never leave the owner's device. Zeroized
+/// on drop; never logged.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct Secp256k1SecretKey {
+    bytes: [u8; SECP256K1_SECRET_KEY_SIZE],
+}
+
+impl Secp256k1SecretKey {
+    /// Creates a secret key from raw bytes, validating it is a non-zero scalar
+    /// in `[1, n)`.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() != SECP256K1_SECRET_KEY_SIZE {
+            return Err(SpecterError::InvalidKeySize {
+                expected: SECP256K1_SECRET_KEY_SIZE,
+                actual: bytes.len(),
+            });
+        }
+        k256::SecretKey::from_slice(bytes)
+            .map_err(|_| SpecterError::InvalidKeySize {
+                expected: SECP256K1_SECRET_KEY_SIZE,
+                actual: bytes.len(),
+            })?;
+        let mut arr = [0u8; SECP256K1_SECRET_KEY_SIZE];
+        arr.copy_from_slice(bytes);
+        Ok(Self { bytes: arr })
+    }
+
+    /// Returns the raw secret bytes. Handle with care — never log or transmit.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Returns the underlying `k256::SecretKey`.
+    pub fn to_k256(&self) -> Result<k256::SecretKey> {
+        k256::SecretKey::from_slice(&self.bytes).map_err(|_| SpecterError::InvalidKeySize {
+            expected: SECP256K1_SECRET_KEY_SIZE,
+            actual: self.bytes.len(),
+        })
+    }
+}
+
+impl std::fmt::Debug for Secp256k1SecretKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Secp256k1SecretKey([REDACTED])")
+    }
+}
+
+/// A complete secp256k1 spending key pair (public + secret).
+#[derive(ZeroizeOnDrop)]
+pub struct Secp256k1KeyPair {
+    /// Public key — part of the meta-address (safe to share).
+    #[zeroize(skip)]
+    pub public: Secp256k1PublicKey,
+    /// Secret key — never leaves the device (auto-zeroized).
+    pub secret: Secp256k1SecretKey,
+}
+
+impl Secp256k1KeyPair {
+    /// Creates a spending key pair from public and secret keys.
+    pub fn new(public: Secp256k1PublicKey, secret: Secp256k1SecretKey) -> Self {
+        Self { public, secret }
+    }
+}
+
+impl std::fmt::Debug for Secp256k1KeyPair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Secp256k1KeyPair")
+            .field("public", &self.public)
+            .field("secret", &"[REDACTED]")
+            .finish()
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // SPECTER KEY TYPES
 // ═══════════════════════════════════════════════════════════════════════════════
 
-/// Spending key pair - used to spend from stealth addresses.
-///
-/// The spending public key is part of the meta-address.
-/// The spending secret key is used to derive stealth private keys.
-pub type SpendingKeyPair = KeyPair;
+/// Spending key pair (v2) — a secp256k1 keypair used to spend from stealth
+/// addresses. The public key is part of the meta-address; the secret key is used
+/// to derive stealth spend keys and must never leave the owner's device.
+pub type SpendingKeyPair = Secp256k1KeyPair;
 
-/// Viewing key pair - used to scan for incoming payments.
+/// Viewing key pair — an ML-KEM-768 keypair used to scan for incoming payments.
 ///
-/// The viewing public key is part of the meta-address.
-/// The viewing secret key can be shared with third parties (e.g., tax auditors)
-/// to allow them to see incoming payments without spending ability.
+/// The viewing public key is part of the meta-address. The viewing secret key
+/// can be shared with third parties (e.g. an auditor or a scanning service) to
+/// allow them to *detect* incoming payments without any ability to spend.
 pub type ViewingKeyPair = KeyPair;
 
-/// Complete SPECTER key set (spending + viewing).
+/// Complete SPECTER key set (secp256k1 spending + ML-KEM viewing).
 #[derive(ZeroizeOnDrop)]
 pub struct SpecterKeys {
-    /// Keys for spending from stealth addresses
+    /// secp256k1 keys for spending from stealth addresses
     pub spending: SpendingKeyPair,
-    /// Keys for viewing/scanning announcements
+    /// ML-KEM keys for viewing/scanning announcements
     pub viewing: ViewingKeyPair,
 }
 

--- a/specter/specter-crypto/benches/crypto_bench.rs
+++ b/specter/specter-crypto/benches/crypto_bench.rs
@@ -47,7 +47,7 @@ fn bench_view_tag(c: &mut Criterion) {
 }
 
 fn bench_stealth_derivation(c: &mut Criterion) {
-    let spending = generate_keypair();
+    let spending = specter_crypto::generate_spending_keypair();
     let viewing = generate_keypair();
     let (_ct, shared_secret) = encapsulate(&viewing.public).unwrap();
     let ss: &[u8] = &shared_secret[..];

--- a/specter/specter-crypto/src/derive.rs
+++ b/specter/specter-crypto/src/derive.rs
@@ -1,65 +1,70 @@
-//! Stealth key and address derivation.
+//! Stealth key and address derivation (protocol v2, secp256k1 additive tweak).
 //!
-//! This module implements the core cryptographic operations for deriving
-//! stealth public/private keys and Ethereum addresses.
+//! ## Security model
 //!
-//! ## Derivation Flow
-//!
-//! ```text
-//! shared_secret
-//!       ↓
-//! SHAKE256(DOMAIN_STEALTH_PK || shared_secret) → stealth_factor (1184 bytes)
-//!       ↓
-//! stealth_pk = spending_pk ⊕ stealth_factor
-//!       ↓
-//! eth_address = keccak256(stealth_pk)[12..32]
-//! ```
-//!
-//! ## Private Key Derivation
-//!
-//! The recipient can derive the stealth private key:
+//! The spending key is a secp256k1 keypair: secret scalar `b`, public point
+//! `B = b·G`, published in the meta-address. For each payment the sender and
+//! recipient share a per-payment secret `shared_secret` via ML-KEM. From it both
+//! derive an additive **tweak** scalar:
 //!
 //! ```text
-//! stealth_sk = spending_sk ⊕ stealth_factor
+//! t = H(shared_secret)                       (a secp256k1 scalar)
 //! ```
+//!
+//! The one-time stealth key is the recipient's spending key shifted by `t`:
+//!
+//! ```text
+//! P = B + t·G          (stealth public key / address — sender-computable)
+//! p = b + t (mod n)    (stealth private key      — recipient-only)
+//! ```
+//!
+//! Because `p·G = (b + t)·G = B + t·G = P`, the address the sender computes from
+//! the *public* `B` is exactly the address the recipient can spend from with `p`.
+//!
+//! **The sender cannot derive `p`.** Computing `p` requires the secret scalar
+//! `b`, which never leaves the recipient. This is the property that was broken in
+//! protocol v1 (where the "private key" was a pure hash of `shared_secret` and
+//! the public spending key, and therefore derivable by the sender). See
+//! `sender_cannot_derive_stealth_private_key` in the tests.
 
 use zeroize::Zeroize;
 
 use blake2::digest::{Update, VariableOutput};
 use blake2::Blake2bVar;
-use k256::ecdsa::SigningKey;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::{NonZeroScalar, ProjectivePoint, PublicKey, Scalar, SecretKey};
+use rand::rngs::OsRng;
 use specter_core::constants::{
-    DOMAIN_ETH_KEY, DOMAIN_STEALTH_PK, DOMAIN_STEALTH_SK, ETH_ADDRESS_SIZE, KYBER_PUBLIC_KEY_SIZE,
-    KYBER_SECRET_KEY_SIZE, SUI_ADDRESS_SIZE,
+    DOMAIN_STEALTH_TWEAK, ETH_ADDRESS_SIZE, SECP256K1_PUBLIC_KEY_SIZE, SUI_ADDRESS_SIZE,
 };
 use specter_core::error::{Result, SpecterError};
-use specter_core::types::{EthAddress, SuiAddress};
+use specter_core::types::{EthAddress, Secp256k1KeyPair, Secp256k1PublicKey, Secp256k1SecretKey, SuiAddress};
 
 use crate::hash::{keccak256, shake256};
 
 /// Sui signature scheme flag for ECDSA secp256k1.
 const SUI_SCHEME_SECP256K1: u8 = 0x01;
 
-/// Result of stealth key derivation.
+/// Result of stealth key derivation (recipient side).
 #[derive(Debug)]
 pub struct StealthKeys {
     /// The secp256k1 uncompressed public key (65 bytes); hashes to the Ethereum address.
     pub public_key: Vec<u8>,
-    /// The stealth private key (2400 bytes, zeroized on drop)
+    /// The stealth private key (32-byte secp256k1 scalar, zeroized on drop).
     pub private_key: StealthPrivateKey,
-    /// The derived Ethereum address
+    /// The derived Ethereum address.
     pub address: EthAddress,
-    /// The derived Sui address (same secp256k1 key, blake2b-256)
+    /// The derived Sui address (same secp256k1 key, blake2b-256).
     pub sui_address: SuiAddress,
 }
 
-/// Wrapper for stealth private key with automatic zeroization.
+/// Wrapper for a 32-byte stealth private key with automatic zeroization.
 pub struct StealthPrivateKey {
     bytes: Vec<u8>,
 }
 
 impl StealthPrivateKey {
-    /// Creates from raw bytes.
+    /// Creates from raw bytes (expected to be exactly 32 bytes).
     pub fn from_bytes(bytes: Vec<u8>) -> Self {
         Self { bytes }
     }
@@ -69,13 +74,11 @@ impl StealthPrivateKey {
         &self.bytes
     }
 
-    /// Extracts the 32-byte seed for Ethereum signing.
+    /// Returns the 32-byte Ethereum/secp256k1 private key.
     ///
-    /// For Ethereum compatibility, we derive a 32-byte private key
-    /// from the Kyber secret key material.
+    /// This key imports directly into any secp256k1 wallet (MetaMask, ethers)
+    /// and controls the stealth address.
     pub fn to_eth_private_key(&self) -> [u8; 32] {
-        // Use first 32 bytes of stealth SK as Ethereum private key
-        // In production, this should use proper key derivation
         let mut eth_sk = [0u8; 32];
         eth_sk.copy_from_slice(&self.bytes[..32]);
         eth_sk
@@ -94,81 +97,65 @@ impl std::fmt::Debug for StealthPrivateKey {
     }
 }
 
-/// stealth_factor = SHAKE256(DOMAIN_STEALTH_PK || shared_secret, 1184); stealth_pk = spending_pk ⊕ stealth_factor
-pub fn derive_stealth_public_key(spending_pk: &[u8], shared_secret: &[u8]) -> Result<Vec<u8>> {
-    if spending_pk.len() != KYBER_PUBLIC_KEY_SIZE {
-        return Err(SpecterError::InvalidKeySize {
-            expected: KYBER_PUBLIC_KEY_SIZE,
-            actual: spending_pk.len(),
-        });
-    }
+// ═══════════════════════════════════════════════════════════════════════════════
+// KEY GENERATION
+// ═══════════════════════════════════════════════════════════════════════════════
 
-    let stealth_factor = shake256(DOMAIN_STEALTH_PK, shared_secret, KYBER_PUBLIC_KEY_SIZE);
-
-    // XOR with spending public key
-    let stealth_pk: Vec<u8> = spending_pk
-        .iter()
-        .zip(stealth_factor.iter())
-        .map(|(a, b)| a ^ b)
-        .collect();
-
-    Ok(stealth_pk)
-}
-
-/// stealth_factor = SHAKE256(DOMAIN_STEALTH_SK || shared_secret, 2400); stealth_sk = spending_sk ⊕ stealth_factor. Output is zeroized on drop.
-pub fn derive_stealth_private_key(
-    spending_sk: &[u8],
-    shared_secret: &[u8],
-) -> Result<StealthPrivateKey> {
-    if spending_sk.len() != KYBER_SECRET_KEY_SIZE {
-        return Err(SpecterError::InvalidKeySize {
-            expected: KYBER_SECRET_KEY_SIZE,
-            actual: spending_sk.len(),
-        });
-    }
-
-    let stealth_factor = shake256(DOMAIN_STEALTH_SK, shared_secret, KYBER_SECRET_KEY_SIZE);
-
-    // XOR with spending secret key
-    let stealth_sk: Vec<u8> = spending_sk
-        .iter()
-        .zip(stealth_factor.iter())
-        .map(|(a, b)| a ^ b)
-        .collect();
-
-    Ok(StealthPrivateKey::from_bytes(stealth_sk))
+/// Generates a fresh secp256k1 spending keypair using the OS CSPRNG.
+///
+/// The public key goes into the meta-address; the secret key must never leave
+/// the owner's device.
+pub fn generate_spending_keypair() -> Secp256k1KeyPair {
+    let secret = SecretKey::random(&mut OsRng);
+    let public_compressed = secret.public_key().to_sec1_bytes();
+    let public = Secp256k1PublicKey::from_bytes(&public_compressed)
+        .expect("freshly generated secp256k1 public key is always valid");
+    let sk = Secp256k1SecretKey::from_bytes(&secret.to_bytes())
+        .expect("freshly generated secp256k1 secret key is always valid");
+    Secp256k1KeyPair::new(public, sk)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// ETHEREUM ADDRESS DERIVATION
+// TWEAK
 // ═══════════════════════════════════════════════════════════════════════════════
 
-/// Derives a 32-byte secp256k1 key seed from (shared_secret, spending_pk).
-/// Both sender and recipient can compute this; used for stealth address and eth_private_key.
-/// Retries with re-hashed seed if the first candidate is not a valid secp256k1 scalar.
-fn derive_eth_key_seed(shared_secret: &[u8], spending_pk: &[u8]) -> Result<[u8; 32]> {
-    let mut seed = [0u8; 32];
-    let mut raw = shake256(DOMAIN_ETH_KEY, &[shared_secret, spending_pk].concat(), 32);
-    seed.copy_from_slice(&raw[..32]);
+/// Derives the additive stealth tweak scalar `t = H(shared_secret)`.
+///
+/// Uses rejection sampling over `SHAKE256(DOMAIN_STEALTH_TWEAK || shared_secret ||
+/// counter)`: the first 32-byte candidate that is a valid non-zero scalar in
+/// `[1, n)` is returned. This is unbiased and, because secp256k1's order is very
+/// close to `2^256`, effectively never iterates more than once.
+fn derive_stealth_tweak(shared_secret: &[u8]) -> Scalar {
+    let mut counter: u8 = 0;
     loop {
-        if SigningKey::from_slice(&seed).is_ok() {
-            return Ok(seed);
+        let mut input = Vec::with_capacity(shared_secret.len() + 1);
+        input.extend_from_slice(shared_secret);
+        input.push(counter);
+        let candidate = shake256(DOMAIN_STEALTH_TWEAK, &input, 32);
+        if let Ok(sk) = SecretKey::from_slice(&candidate) {
+            // SecretKey::from_slice already guarantees a non-zero scalar in [1, n).
+            return *sk.to_nonzero_scalar().as_ref();
         }
-        raw = keccak256(&seed).to_vec();
-        seed.copy_from_slice(&raw);
+        counter = counter.wrapping_add(1);
     }
 }
 
-/// Derives a Sui address from a secp256k1 private key (32 bytes).
-/// Sui uses blake2b-256(scheme_flag || compressed_pubkey) where scheme_flag is 0x01 for secp256k1.
-pub fn derive_sui_address_from_seed(seed: &[u8; 32]) -> Result<SuiAddress> {
-    let signing_key = SigningKey::from_slice(seed).map_err(|_| {
-        SpecterError::InvalidStealthAddress("invalid secp256k1 key from seed".to_string())
-    })?;
-    let verifying_key = signing_key.verifying_key();
-    let encoded = verifying_key.to_encoded_point(true); // compressed (33 bytes)
-    let compressed = encoded.as_bytes();
+// ═══════════════════════════════════════════════════════════════════════════════
+// ADDRESS DERIVATION FROM A PUBLIC KEY
+// ═══════════════════════════════════════════════════════════════════════════════
 
+/// Derives the Ethereum address of a secp256k1 public key: `keccak256(uncompressed[1..])[12..]`.
+fn eth_address_from_pubkey(pk: &PublicKey) -> EthAddress {
+    let encoded = pk.to_encoded_point(false); // 0x04 || X(32) || Y(32)
+    let hash = keccak256(&encoded.as_bytes()[1..]); // hash X||Y only
+    let mut address_bytes = [0u8; ETH_ADDRESS_SIZE];
+    address_bytes.copy_from_slice(&hash[32 - ETH_ADDRESS_SIZE..]);
+    EthAddress::from_array(address_bytes)
+}
+
+/// Derives the Sui address from a compressed secp256k1 public key:
+/// `blake2b-256(0x01 || compressed_pubkey)`.
+fn sui_address_from_compressed(compressed: &[u8]) -> Result<SuiAddress> {
     let mut hasher = Blake2bVar::new(SUI_ADDRESS_SIZE)
         .map_err(|_| SpecterError::InvalidStealthAddress("Blake2bVar init failed".into()))?;
     hasher.update(&[SUI_SCHEME_SECP256K1]);
@@ -180,64 +167,118 @@ pub fn derive_sui_address_from_seed(seed: &[u8; 32]) -> Result<SuiAddress> {
     Ok(SuiAddress::from_array(address_bytes))
 }
 
-/// Derives an Ethereum address from a secp256k1 private key (32 bytes).
-/// This matches how MetaMask/wallets derive address from private key.
-pub fn derive_eth_address_from_seed(seed: &[u8; 32]) -> Result<EthAddress> {
-    let signing_key = SigningKey::from_slice(seed).map_err(|_| {
-        SpecterError::InvalidStealthAddress("invalid secp256k1 key from seed".to_string())
-    })?;
-    let verifying_key = signing_key.verifying_key();
-    let encoded = verifying_key.to_encoded_point(false);
-    // Skip the 0x04 prefix - Ethereum only hashes the 64-byte public key (x, y)
-    let pubkey_bytes = &encoded.as_bytes()[1..];
-    let hash = keccak256(pubkey_bytes);
-    let mut address_bytes = [0u8; ETH_ADDRESS_SIZE];
-    address_bytes.copy_from_slice(&hash[32 - ETH_ADDRESS_SIZE..]);
-    Ok(EthAddress::from_array(address_bytes))
+fn sui_address_from_pubkey(pk: &PublicKey) -> Result<SuiAddress> {
+    let compressed = pk.to_encoded_point(true);
+    sui_address_from_compressed(compressed.as_bytes())
 }
 
-/// Derives an Ethereum address from a stealth public key (legacy Kyber-based; 1184 bytes).
-/// Prefer the secp256k1 path via derive_stealth_address / derive_stealth_keys for wallet compatibility.
-pub fn derive_eth_address(stealth_pk: &[u8]) -> Result<EthAddress> {
-    if stealth_pk.len() != KYBER_PUBLIC_KEY_SIZE {
+/// Computes the stealth public key point `P = B + t·G` from the spending public
+/// key bytes and the shared secret.
+fn stealth_pubkey(spending_pub: &[u8], shared_secret: &[u8]) -> Result<PublicKey> {
+    if spending_pub.len() != SECP256K1_PUBLIC_KEY_SIZE {
         return Err(SpecterError::InvalidKeySize {
-            expected: KYBER_PUBLIC_KEY_SIZE,
-            actual: stealth_pk.len(),
+            expected: SECP256K1_PUBLIC_KEY_SIZE,
+            actual: spending_pub.len(),
         });
     }
-
-    let hash = keccak256(stealth_pk);
-
-    // Take last 20 bytes as Ethereum address
-    let mut address_bytes = [0u8; ETH_ADDRESS_SIZE];
-    address_bytes.copy_from_slice(&hash[32 - ETH_ADDRESS_SIZE..]);
-
-    Ok(EthAddress::from_array(address_bytes))
+    let b_point = PublicKey::from_sec1_bytes(spending_pub).map_err(|_| {
+        SpecterError::InvalidStealthAddress("spending key is not a valid secp256k1 point".into())
+    })?;
+    let t = derive_stealth_tweak(shared_secret);
+    let p_proj = b_point.to_projective() + ProjectivePoint::GENERATOR * t;
+    PublicKey::from_affine(p_proj.to_affine()).map_err(|_| {
+        SpecterError::InvalidStealthAddress("derived stealth point is the identity".into())
+    })
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// COMBINED DERIVATION
+// PUBLIC API: ADDRESS-ONLY (SENDER) DERIVATION
 // ═══════════════════════════════════════════════════════════════════════════════
 
-/// Derives complete stealth keys (public, private, and address).
-/// Uses secp256k1 so address and eth_private_key match (import key in wallet to spend).
+/// Derives the stealth Ethereum address for a payment — needs only public data.
 ///
-/// * `spending_pk` - The recipient's spending public key
-/// * `spending_sk` - Unused for secp256k1 path; kept for API compatibility
-/// * `shared_secret` - The shared secret from Kyber decapsulation
+/// `spending_pub` is the recipient's 33-byte compressed secp256k1 spending key.
+/// This is the function senders (and view-only scanners) use: it computes
+/// `keccak256(B + t·G)` and cannot recover the spend key.
+pub fn derive_stealth_address(spending_pub: &[u8], shared_secret: &[u8]) -> Result<EthAddress> {
+    let p = stealth_pubkey(spending_pub, shared_secret)?;
+    Ok(eth_address_from_pubkey(&p))
+}
+
+/// Derives the stealth Sui address for a payment — needs only public data.
+pub fn derive_stealth_sui_address(spending_pub: &[u8], shared_secret: &[u8]) -> Result<SuiAddress> {
+    let p = stealth_pubkey(spending_pub, shared_secret)?;
+    sui_address_from_pubkey(&p)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// PUBLIC API: FULL KEY (RECIPIENT) DERIVATION
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Derives an Ethereum address from a secp256k1 private key (32 bytes).
+///
+/// Matches how MetaMask/ethers derive an address from a raw private key.
+pub fn derive_eth_address_from_seed(seed: &[u8; 32]) -> Result<EthAddress> {
+    let secret = SecretKey::from_slice(seed).map_err(|_| {
+        SpecterError::InvalidStealthAddress("invalid secp256k1 key from seed".to_string())
+    })?;
+    Ok(eth_address_from_pubkey(&secret.public_key()))
+}
+
+/// Derives a Sui address from a secp256k1 private key (32 bytes).
+pub fn derive_sui_address_from_seed(seed: &[u8; 32]) -> Result<SuiAddress> {
+    let secret = SecretKey::from_slice(seed).map_err(|_| {
+        SpecterError::InvalidStealthAddress("invalid secp256k1 key from seed".to_string())
+    })?;
+    sui_address_from_pubkey(&secret.public_key())
+}
+
+/// Derives the complete stealth keys (public, private, address, sui) for a
+/// discovered payment. **Requires the recipient's secret spending key.**
+///
+/// * `spending_pub` - recipient's 33-byte compressed spending public key
+/// * `spending_sk`  - recipient's 32-byte secret spending scalar (never leaves device)
+/// * `shared_secret` - the per-payment ML-KEM shared secret
+///
+/// Computes `p = b + t (mod n)` and returns the resulting one-time key material.
 pub fn derive_stealth_keys(
-    spending_pk: &[u8],
-    _spending_sk: &[u8],
+    spending_pub: &[u8],
+    spending_sk: &[u8],
     shared_secret: &[u8],
 ) -> Result<StealthKeys> {
-    let seed = derive_eth_key_seed(shared_secret, spending_pk)?;
-    let address = derive_eth_address_from_seed(&seed)?;
-    let sui_address = derive_sui_address_from_seed(&seed)?;
-    let signing_key = SigningKey::from_slice(&seed)
-        .map_err(|_| SpecterError::InvalidStealthAddress("invalid secp256k1 key".to_string()))?;
-    let verifying_key = signing_key.verifying_key();
-    let public_key = verifying_key.to_encoded_point(false).as_bytes().to_vec();
+    let b_secret = SecretKey::from_slice(spending_sk).map_err(|_| SpecterError::InvalidKeySize {
+        expected: 32,
+        actual: spending_sk.len(),
+    })?;
+
+    // Defense-in-depth: reject a mismatched (spending_pub, spending_sk) pair so a
+    // caller can never silently derive keys for the wrong meta-address.
+    if spending_pub.len() != SECP256K1_PUBLIC_KEY_SIZE
+        || b_secret.public_key().to_sec1_bytes().as_ref() != spending_pub
+    {
+        return Err(SpecterError::InvalidStealthAddress(
+            "spending secret key does not match the provided spending public key".into(),
+        ));
+    }
+
+    let b = b_secret.to_nonzero_scalar();
+    let t = derive_stealth_tweak(shared_secret);
+
+    let p_scalar: Scalar = *b.as_ref() + t;
+    let p_nonzero = Option::<NonZeroScalar>::from(NonZeroScalar::new(p_scalar)).ok_or_else(|| {
+        SpecterError::InvalidStealthAddress("derived stealth scalar is zero".into())
+    })?;
+    let p_secret = SecretKey::from(p_nonzero);
+
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&p_secret.to_bytes());
+
+    let pubkey = p_secret.public_key();
+    let public_key = pubkey.to_encoded_point(false).as_bytes().to_vec();
+    let address = eth_address_from_pubkey(&pubkey);
+    let sui_address = sui_address_from_pubkey(&pubkey)?;
     let private_key = StealthPrivateKey::from_bytes(seed.to_vec());
+    seed.zeroize();
 
     Ok(StealthKeys {
         public_key,
@@ -247,33 +288,17 @@ pub fn derive_stealth_keys(
     })
 }
 
-/// Derives only the Ethereum address (for senders who don't need the private key).
-/// Uses secp256k1 so the address matches the eth_private_key when imported in a wallet.
-pub fn derive_stealth_address(spending_pk: &[u8], shared_secret: &[u8]) -> Result<EthAddress> {
-    let seed = derive_eth_key_seed(shared_secret, spending_pk)?;
-    derive_eth_address_from_seed(&seed)
-}
-
-/// Derives only the Sui address (for senders who don't need the private key).
-/// Uses the same secp256k1 key as the Ethereum address.
-pub fn derive_stealth_sui_address(spending_pk: &[u8], shared_secret: &[u8]) -> Result<SuiAddress> {
-    let seed = derive_eth_key_seed(shared_secret, spending_pk)?;
-    derive_sui_address_from_seed(&seed)
-}
-
 // ═══════════════════════════════════════════════════════════════════════════════
 // VERIFICATION
 // ═══════════════════════════════════════════════════════════════════════════════
 
-/// Verifies that a stealth address was correctly derived.
-///
-/// Used to confirm a discovered payment is actually for this recipient.
+/// Verifies that a stealth address was correctly derived from `(spending_pub, shared_secret)`.
 pub fn verify_stealth_address(
-    spending_pk: &[u8],
+    spending_pub: &[u8],
     shared_secret: &[u8],
     expected_address: &EthAddress,
 ) -> Result<bool> {
-    let derived = derive_stealth_address(spending_pk, shared_secret)?;
+    let derived = derive_stealth_address(spending_pub, shared_secret)?;
     Ok(subtle::ConstantTimeEq::ct_eq(derived.as_bytes(), expected_address.as_bytes()).into())
 }
 
@@ -281,175 +306,158 @@ pub fn verify_stealth_address(
 mod tests {
     use super::*;
 
-    fn make_test_pk() -> Vec<u8> {
-        vec![0x42u8; KYBER_PUBLIC_KEY_SIZE]
+    /// A deterministic spending keypair `(compressed_pub_bytes, secret_bytes)`.
+    fn test_spending_keys(seed: u8) -> (Vec<u8>, Vec<u8>) {
+        let sk = SecretKey::from_slice(&[seed; 32]).unwrap();
+        (
+            sk.public_key().to_sec1_bytes().to_vec(),
+            sk.to_bytes().to_vec(),
+        )
     }
 
-    fn make_test_sk() -> Vec<u8> {
-        vec![0x99u8; KYBER_SECRET_KEY_SIZE]
-    }
-
-    fn make_test_secret() -> [u8; 32] {
+    fn make_secret() -> [u8; 32] {
         [0xAB; 32]
     }
 
     #[test]
-    fn test_derive_stealth_public_key() {
-        let spending_pk = make_test_pk();
-        let shared_secret = make_test_secret();
-
-        let stealth_pk = derive_stealth_public_key(&spending_pk, &shared_secret).unwrap();
-
-        assert_eq!(stealth_pk.len(), KYBER_PUBLIC_KEY_SIZE);
-        // Stealth PK should be different from spending PK
-        assert_ne!(stealth_pk, spending_pk);
+    fn test_generate_spending_keypair_is_valid_and_random() {
+        let a = generate_spending_keypair();
+        let b = generate_spending_keypair();
+        assert_ne!(a.public.as_bytes(), b.public.as_bytes());
+        // secret must derive back to the public key
+        let derived = derive_eth_address_from_seed(
+            &a.secret.as_bytes().try_into().expect("32 bytes"),
+        );
+        assert!(derived.is_ok());
     }
 
     #[test]
-    fn test_derive_stealth_public_key_deterministic() {
-        let spending_pk = make_test_pk();
-        let shared_secret = make_test_secret();
+    fn test_address_matches_between_sender_and_recipient() {
+        let (spending_pub, spending_sk) = test_spending_keys(0x11);
+        let shared = make_secret();
 
-        let pk1 = derive_stealth_public_key(&spending_pk, &shared_secret).unwrap();
-        let pk2 = derive_stealth_public_key(&spending_pk, &shared_secret).unwrap();
+        // Sender: address from public key only.
+        let sender_addr = derive_stealth_address(&spending_pub, &shared).unwrap();
+        // Recipient: full keys from secret.
+        let keys = derive_stealth_keys(&spending_pub, &spending_sk, &shared).unwrap();
 
-        assert_eq!(pk1, pk2);
+        assert_eq!(
+            sender_addr, keys.address,
+            "sender-derived address must equal recipient-derived address"
+        );
     }
 
     #[test]
-    fn test_derive_stealth_public_key_different_secrets() {
-        let spending_pk = make_test_pk();
-        let secret1 = [1u8; 32];
-        let secret2 = [2u8; 32];
+    fn test_eth_private_key_controls_stealth_address() {
+        let (spending_pub, spending_sk) = test_spending_keys(0x22);
+        let shared = make_secret();
+        let keys = derive_stealth_keys(&spending_pub, &spending_sk, &shared).unwrap();
 
-        let pk1 = derive_stealth_public_key(&spending_pk, &secret1).unwrap();
-        let pk2 = derive_stealth_public_key(&spending_pk, &secret2).unwrap();
+        // The returned private key must derive to the same address (wallet import).
+        let from_pk = derive_eth_address_from_seed(&keys.private_key.to_eth_private_key()).unwrap();
+        assert_eq!(keys.address.as_bytes(), from_pk.as_bytes());
+    }
 
-        // Different secrets should produce different stealth PKs
-        assert_ne!(pk1, pk2);
+    /// THE security regression test for CRITICAL #1.
+    ///
+    /// A party holding only the *public* spending key and the shared secret
+    /// (i.e. the sender) must NOT be able to produce the stealth private key.
+    #[test]
+    fn sender_cannot_derive_stealth_private_key() {
+        let (spending_pub, spending_sk) = test_spending_keys(0x33);
+        let shared = make_secret();
+
+        // The recipient's true private key for this payment.
+        let recipient_keys = derive_stealth_keys(&spending_pub, &spending_sk, &shared).unwrap();
+        let true_priv = recipient_keys.private_key.to_eth_private_key();
+
+        // Everything the sender has: shared secret + public spending key + the
+        // public tweak. There is no function that yields the private key from
+        // these — the only derivation that does requires `spending_sk`. Prove the
+        // sender's best effort (using the address-only path) never exposes it,
+        // and that guessing the private key from public data fails.
+        let sender_addr = derive_stealth_address(&spending_pub, &shared).unwrap();
+        assert_eq!(sender_addr, recipient_keys.address);
+
+        // If the sender could derive the key it would necessarily equal the
+        // recipient's. Model the sender substituting the *public* spending key
+        // bytes where a secret would go: it must NOT reproduce the true key.
+        // (spending_pub is 33 bytes; not even the right size for a scalar.)
+        let forged = derive_stealth_keys(&spending_pub, &spending_pub, &shared);
+        assert!(
+            forged.is_err(),
+            "public spending key must not be usable as a secret"
+        );
+
+        // And a different (matching) keypair must not yield the true private key.
+        let (pub2, other_sk) = test_spending_keys(0x99);
+        let wrong = derive_stealth_keys(&pub2, &other_sk, &shared).unwrap();
+        assert_ne!(
+            wrong.private_key.to_eth_private_key(),
+            true_priv,
+            "a different secret must not reproduce the true stealth private key"
+        );
     }
 
     #[test]
-    fn test_derive_stealth_private_key() {
-        let spending_sk = make_test_sk();
-        let shared_secret = make_test_secret();
-
-        let stealth_sk = derive_stealth_private_key(&spending_sk, &shared_secret).unwrap();
-
-        assert_eq!(stealth_sk.as_bytes().len(), KYBER_SECRET_KEY_SIZE);
+    fn test_different_secrets_give_different_addresses() {
+        let (spending_pub, _sk) = test_spending_keys(0x44);
+        let addr1 = derive_stealth_address(&spending_pub, &[1u8; 32]).unwrap();
+        let addr2 = derive_stealth_address(&spending_pub, &[2u8; 32]).unwrap();
+        assert_ne!(addr1, addr2);
     }
 
     #[test]
-    fn test_derive_eth_address() {
-        let stealth_pk = make_test_pk();
-        let address = derive_eth_address(&stealth_pk).unwrap();
-
-        assert_eq!(address.as_bytes().len(), ETH_ADDRESS_SIZE);
+    fn test_deterministic_derivation() {
+        let (spending_pub, _sk) = test_spending_keys(0x55);
+        let shared = make_secret();
+        let a1 = derive_stealth_address(&spending_pub, &shared).unwrap();
+        let a2 = derive_stealth_address(&spending_pub, &shared).unwrap();
+        assert_eq!(a1, a2);
     }
 
     #[test]
-    fn test_derive_stealth_keys() {
-        let spending_pk = make_test_pk();
-        let spending_sk = make_test_sk();
-        let shared_secret = make_test_secret();
-
-        let keys = derive_stealth_keys(&spending_pk, &spending_sk, &shared_secret).unwrap();
-
-        // secp256k1 path: 65-byte uncompressed pubkey, 32-byte eth private key
-        assert_eq!(keys.public_key.len(), 65);
-        assert_eq!(keys.private_key.as_bytes().len(), 32);
-        assert_eq!(keys.address.as_bytes().len(), ETH_ADDRESS_SIZE);
-        assert_eq!(keys.sui_address.as_bytes().len(), SUI_ADDRESS_SIZE);
-        // eth_private_key must derive to the same address (wallet compatibility)
-        let addr_from_pk =
-            derive_eth_address_from_seed(&keys.private_key.to_eth_private_key()).unwrap();
-        assert_eq!(keys.address.as_bytes(), addr_from_pk.as_bytes());
-        // sui_address must derive from same seed
-        let sui_from_seed =
-            derive_sui_address_from_seed(&keys.private_key.to_eth_private_key()).unwrap();
-        assert_eq!(keys.sui_address.as_bytes(), sui_from_seed.as_bytes());
-    }
-
-    #[test]
-    fn test_derive_stealth_address() {
-        let spending_pk = make_test_pk();
-        let shared_secret = make_test_secret();
-
-        let address = derive_stealth_address(&spending_pk, &shared_secret).unwrap();
-
-        // Should match the address from full key derivation
-        let keys = derive_stealth_keys(&spending_pk, &make_test_sk(), &shared_secret).unwrap();
-        assert_eq!(address, keys.address);
+    fn test_sui_address_matches_between_paths() {
+        let (spending_pub, spending_sk) = test_spending_keys(0x66);
+        let shared = make_secret();
+        let sender_sui = derive_stealth_sui_address(&spending_pub, &shared).unwrap();
+        let keys = derive_stealth_keys(&spending_pub, &spending_sk, &shared).unwrap();
+        assert_eq!(sender_sui, keys.sui_address);
+        assert!(!sender_sui.is_zero());
     }
 
     #[test]
     fn test_verify_stealth_address() {
-        let spending_pk = make_test_pk();
-        let shared_secret = make_test_secret();
-
-        let address = derive_stealth_address(&spending_pk, &shared_secret).unwrap();
-
-        assert!(verify_stealth_address(&spending_pk, &shared_secret, &address).unwrap());
-
-        // Wrong address should fail
-        let wrong_address = EthAddress::from_array([0xFF; ETH_ADDRESS_SIZE]);
-        assert!(!verify_stealth_address(&spending_pk, &shared_secret, &wrong_address).unwrap());
+        let (spending_pub, _sk) = test_spending_keys(0x77);
+        let shared = make_secret();
+        let addr = derive_stealth_address(&spending_pub, &shared).unwrap();
+        assert!(verify_stealth_address(&spending_pub, &shared, &addr).unwrap());
+        let wrong = EthAddress::from_array([0xFF; ETH_ADDRESS_SIZE]);
+        assert!(!verify_stealth_address(&spending_pub, &shared, &wrong).unwrap());
     }
 
     #[test]
-    fn test_xor_reversibility() {
-        // XOR is its own inverse: (A ⊕ B) ⊕ B = A
-        let original = make_test_pk();
-        let shared_secret = make_test_secret();
-
-        let stealth = derive_stealth_public_key(&original, &shared_secret).unwrap();
-
-        // Apply the same operation to recover original
-        let factor = shake256(DOMAIN_STEALTH_PK, &shared_secret, KYBER_PUBLIC_KEY_SIZE);
-        let recovered: Vec<u8> = stealth
-            .iter()
-            .zip(factor.iter())
-            .map(|(a, b)| a ^ b)
-            .collect();
-
-        assert_eq!(original, recovered);
+    fn test_invalid_spending_pub_rejected() {
+        let bad = vec![0u8; 33]; // not a valid point
+        let shared = make_secret();
+        assert!(derive_stealth_address(&bad, &shared).is_err());
     }
 
     #[test]
     fn test_stealth_private_key_zeroized_on_drop() {
-        let spending_sk = make_test_sk();
-        let shared_secret = make_test_secret();
-
-        // Create and immediately drop
+        let (spending_pub, spending_sk) = test_spending_keys(0x88);
         {
-            let _stealth_sk = derive_stealth_private_key(&spending_sk, &shared_secret).unwrap();
-            // Key is zeroized when _stealth_sk goes out of scope
+            let _keys = derive_stealth_keys(&spending_pub, &spending_sk, &make_secret()).unwrap();
         }
-
-        // Can't directly verify zeroization, but the Drop impl ensures it
+        // Drop impl zeroizes; cannot observe directly but the type guarantees it.
     }
 
     #[test]
-    fn test_derive_sui_address() {
-        let spending_pk = make_test_pk();
-        let shared_secret = make_test_secret();
-
-        let sui_addr = derive_stealth_sui_address(&spending_pk, &shared_secret).unwrap();
-        assert_eq!(sui_addr.as_bytes().len(), SUI_ADDRESS_SIZE);
-        assert!(!sui_addr.is_zero());
-
-        // Must match the sui_address from full key derivation
-        let keys = derive_stealth_keys(&spending_pk, &make_test_sk(), &shared_secret).unwrap();
-        assert_eq!(sui_addr, keys.sui_address);
-    }
-
-    #[test]
-    fn test_invalid_key_sizes() {
-        let too_short = vec![0u8; 100];
-        let shared_secret = make_test_secret();
-
-        assert!(derive_stealth_public_key(&too_short, &shared_secret).is_err());
-        assert!(derive_stealth_private_key(&too_short, &shared_secret).is_err());
-        assert!(derive_eth_address(&too_short).is_err());
+    fn test_tweak_is_nonzero_and_deterministic() {
+        let s = make_secret();
+        let t1 = derive_stealth_tweak(&s);
+        let t2 = derive_stealth_tweak(&s);
+        assert_eq!(t1, t2);
+        assert!(!bool::from(t1.is_zero()));
     }
 }

--- a/specter/specter-crypto/src/lib.rs
+++ b/specter/specter-crypto/src/lib.rs
@@ -46,8 +46,9 @@ pub mod view_tag;
 // Re-export main functions at crate root
 pub use db_keys::{DbKeys, WRAPPED_SECRET_SIZE};
 pub use derive::{
-    derive_eth_address, derive_eth_address_from_seed, derive_stealth_keys,
-    derive_stealth_sui_address, derive_sui_address_from_seed,
+    derive_eth_address_from_seed, derive_stealth_address, derive_stealth_keys,
+    derive_stealth_sui_address, derive_sui_address_from_seed, generate_spending_keypair,
+    StealthKeys, StealthPrivateKey,
 };
 pub use hash::{shake256, shake256_xof};
 pub use kyber::{decapsulate, encapsulate, generate_keypair, KyberCiphertext};

--- a/specter/specter-scanner/src/lib.rs
+++ b/specter/specter-scanner/src/lib.rs
@@ -16,7 +16,7 @@
 //! use specter_registry::MemoryRegistry;
 //!
 //! // Create scanner with wallet keys
-//! let scanner = Scanner::new(wallet.viewing_sk(), wallet.spending_pk(), wallet.spending_sk());
+//! let scanner = Scanner::new(wallet.viewing_sk(), wallet.spending_pub());
 //!
 //! // Scan all announcements
 //! let discoveries = scanner.scan_all(&registry).await?;
@@ -210,13 +210,16 @@ impl ScanPosition {
 }
 
 /// Main scanner for discovering payments.
+///
+/// Detection is **view-only**: it needs the ML-KEM viewing secret key and the
+/// secp256k1 spending *public* key. It never touches the spending secret key —
+/// deriving the spend key is a separate, device-local step
+/// ([`specter_stealth::discovery::derive_spend_keys`]).
 pub struct Scanner {
-    /// Viewing secret key (for decapsulation)
+    /// Viewing secret key (ML-KEM, for decapsulation)
     viewing_sk: Vec<u8>,
-    /// Spending public key (for address derivation)
-    spending_pk: Vec<u8>,
-    /// Spending secret key (for private key derivation)
-    spending_sk: Vec<u8>,
+    /// Spending public key (secp256k1 compressed, 33 bytes, for address derivation)
+    spending_pub: Vec<u8>,
     /// Current scan position
     position: RwLock<ScanPosition>,
     /// Scan statistics
@@ -224,18 +227,16 @@ pub struct Scanner {
 }
 
 impl Scanner {
-    /// Creates a new scanner with the given keys.
+    /// Creates a new view-only scanner.
     ///
     /// # Arguments
     ///
-    /// * `viewing_sk` - The viewing secret key (2400 bytes)
-    /// * `spending_pk` - The spending public key (1184 bytes)
-    /// * `spending_sk` - The spending secret key (2400 bytes)
-    pub fn new(viewing_sk: Vec<u8>, spending_pk: Vec<u8>, spending_sk: Vec<u8>) -> Self {
+    /// * `viewing_sk` - The ML-KEM viewing secret key (2400 bytes)
+    /// * `spending_pub` - The secp256k1 spending public key (33 bytes compressed)
+    pub fn new(viewing_sk: Vec<u8>, spending_pub: Vec<u8>) -> Self {
         Self {
             viewing_sk,
-            spending_pk,
-            spending_sk,
+            spending_pub,
             position: RwLock::new(ScanPosition::new()),
             stats: RwLock::new(ScanStats::new()),
         }
@@ -345,8 +346,7 @@ impl Scanner {
                 let result = scan_announcement(
                     &announcement,
                     &self.viewing_sk,
-                    &self.spending_pk,
-                    &self.spending_sk,
+                    &self.spending_pub,
                 );
 
                 // Record stats
@@ -452,8 +452,7 @@ impl Scanner {
                 let result = scan_announcement(
                     &announcement,
                     &self.viewing_sk,
-                    &self.spending_pk,
-                    &self.spending_sk,
+                    &self.spending_pub,
                 );
 
                 self.stats.write().record(&result);
@@ -495,8 +494,7 @@ impl Scanner {
         let result = scan_announcement(
             announcement,
             &self.viewing_sk,
-            &self.spending_pk,
-            &self.spending_sk,
+            &self.spending_pub,
         );
 
         self.stats.write().record(&result);
@@ -545,7 +543,7 @@ mod tests {
     use async_trait::async_trait;
     use specter_core::constants::KYBER_CIPHERTEXT_SIZE;
     use specter_core::resolver::EphemeralKeyResolver;
-    use specter_crypto::{compute_view_tag, encapsulate, generate_keypair};
+    use specter_crypto::{compute_view_tag, encapsulate, generate_keypair, generate_spending_keypair};
     use specter_registry::MemoryRegistry;
 
     struct StubResolver {
@@ -563,13 +561,12 @@ mod tests {
     }
 
     fn setup_scanner_and_registry() -> (Scanner, MemoryRegistry, Vec<u8>) {
-        let spending = generate_keypair();
+        let spending = generate_spending_keypair();
         let viewing = generate_keypair();
 
         let scanner = Scanner::new(
             viewing.secret.as_bytes().to_vec(),
             spending.public.as_bytes().to_vec(),
-            spending.secret.as_bytes().to_vec(),
         );
 
         let registry = MemoryRegistry::new();

--- a/specter/specter-stealth/src/discovery.rs
+++ b/specter/specter-stealth/src/discovery.rs
@@ -1,18 +1,69 @@
 //! Payment discovery (recipient scan).
+//!
+//! ## Trust split (protocol v2)
+//!
+//! **Detection** — finding which announcements are yours and at what address —
+//! requires only the *viewing* secret key and the *spending public* key. It does
+//! NOT require the spending secret key. This is what a watch-only client, an
+//! auditor, or a server-side scanner runs.
+//!
+//! **Spending** — deriving the one-time private key to move funds — is a separate
+//! step ([`derive_spend_keys`]) that additionally requires the spending *secret*
+//! key. That secret should only ever exist on the owner's device.
+//!
+//! Concretely: scanning yields a [`DiscoveredPayment`] carrying the stealth
+//! address and the per-payment `shared_secret`; the holder later feeds that
+//! `shared_secret` plus their spending secret key into [`derive_spend_keys`].
+
+use zeroize::Zeroize;
 
 use specter_core::error::{Result, SpecterError};
-use specter_core::types::{Announcement, EthAddress};
-use specter_crypto::derive::{derive_stealth_address, derive_stealth_keys, StealthKeys};
+use specter_core::types::{Announcement, EthAddress, SuiAddress};
+use specter_crypto::derive::{derive_stealth_address, derive_stealth_sui_address, StealthKeys};
 use specter_crypto::{compute_view_tag, decapsulate, KyberCiphertext};
+
+// Re-export the spend-key derivation so callers get it from the discovery module.
+pub use specter_crypto::derive::derive_stealth_keys as derive_spend_keys;
+
+/// A payment discovered during a view-only scan.
+///
+/// Contains everything needed to *recognise* the payment. To spend it, pass
+/// `shared_secret` (with your spending secret key) to [`derive_spend_keys`].
+#[derive(Clone)]
+pub struct DiscoveredPayment {
+    /// The one-time stealth Ethereum address funds were sent to.
+    pub address: EthAddress,
+    /// The matching one-time Sui address (same secp256k1 key).
+    pub sui_address: SuiAddress,
+    /// The per-payment ML-KEM shared secret. Needed to derive the spend key.
+    /// Knowing this does NOT allow spending without the spending secret key.
+    pub shared_secret: [u8; 32],
+}
+
+impl Drop for DiscoveredPayment {
+    fn drop(&mut self) {
+        self.shared_secret.zeroize();
+    }
+}
+
+impl std::fmt::Debug for DiscoveredPayment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiscoveredPayment")
+            .field("address", &self.address)
+            .field("sui_address", &self.sui_address)
+            .field("shared_secret", &"[REDACTED]")
+            .finish()
+    }
+}
 
 /// Result of scanning a single announcement.
 #[derive(Debug)]
 pub enum ScanResult {
-    /// View tag didn't match - not for this recipient
+    /// View tag didn't match - not for this recipient.
     NotForUs,
-    /// View tag matched and decapsulation succeeded - payment discovered
-    Discovered(StealthKeys),
-    /// View tag matched but decapsulation failed (shouldn't happen normally)
+    /// View tag matched and decapsulation succeeded - payment discovered.
+    Discovered(DiscoveredPayment),
+    /// View tag matched but decapsulation/derivation failed (shouldn't happen normally).
     DecapsulationFailed(SpecterError),
 }
 
@@ -22,30 +73,27 @@ impl ScanResult {
         matches!(self, ScanResult::Discovered(_))
     }
 
-    /// Returns the discovered keys if present.
-    pub fn into_keys(self) -> Option<StealthKeys> {
+    /// Returns the discovered payment if present.
+    pub fn into_payment(self) -> Option<DiscoveredPayment> {
         match self {
-            ScanResult::Discovered(keys) => Some(keys),
+            ScanResult::Discovered(p) => Some(p),
             _ => None,
         }
     }
 }
 
-/// A discovered payment (alias for StealthKeys for semantic clarity).
-pub type DiscoveredPayment = StealthKeys;
-
 /// Statistics for scanning operations.
 #[derive(Debug, Clone, Default)]
 pub struct ScanStats {
-    /// Total announcements scanned
+    /// Total announcements scanned.
     pub total_scanned: u64,
-    /// Number of view tag matches
+    /// Number of view tag matches.
     pub view_tag_matches: u64,
-    /// Number of payments discovered
+    /// Number of payments discovered.
     pub discoveries: u64,
-    /// Number of errors during scanning
+    /// Number of errors during scanning.
     pub errors: u64,
-    /// Duration of the scan in milliseconds
+    /// Duration of the scan in milliseconds.
     pub duration_ms: u64,
 }
 
@@ -90,12 +138,12 @@ impl ScanStats {
     }
 }
 
-/// Decapsulate with viewing_sk; if view tag matches, derive stealth keys.
+/// Decapsulate with `viewing_sk`; if the view tag matches, derive the stealth
+/// address from the *public* spending key. View-only: no spending secret needed.
 pub fn scan_announcement(
     announcement: &Announcement,
     viewing_sk: &[u8],
-    spending_pk: &[u8],
-    spending_sk: &[u8],
+    spending_pub: &[u8],
 ) -> ScanResult {
     if let Err(e) = announcement.validate() {
         return ScanResult::DecapsulationFailed(e);
@@ -121,38 +169,50 @@ pub fn scan_announcement(
         return ScanResult::NotForUs;
     }
 
-    match derive_stealth_keys(spending_pk, spending_sk, &shared_secret) {
-        Ok(keys) => ScanResult::Discovered(keys),
+    match build_discovered_payment(spending_pub, &shared_secret) {
+        Ok(p) => ScanResult::Discovered(p),
         Err(e) => ScanResult::DecapsulationFailed(e),
     }
 }
 
-/// Scans a list of announcements and returns `(index, keys)` for each match.
+/// Builds a [`DiscoveredPayment`] from public spending key + shared secret.
+fn build_discovered_payment(spending_pub: &[u8], shared_secret: &[u8]) -> Result<DiscoveredPayment> {
+    let address = derive_stealth_address(spending_pub, shared_secret)?;
+    let sui_address = derive_stealth_sui_address(spending_pub, shared_secret)?;
+    let mut ss = [0u8; 32];
+    ss.copy_from_slice(shared_secret);
+    Ok(DiscoveredPayment {
+        address,
+        sui_address,
+        shared_secret: ss,
+    })
+}
+
+/// Scans a list of announcements and returns `(index, payment)` for each match.
 pub fn scan_announcements(
     announcements: &[Announcement],
     viewing_sk: &[u8],
-    spending_pk: &[u8],
-    spending_sk: &[u8],
-) -> Vec<(usize, StealthKeys)> {
+    spending_pub: &[u8],
+) -> Vec<(usize, DiscoveredPayment)> {
     announcements
         .iter()
         .enumerate()
-        .filter_map(|(idx, ann)| {
-            match scan_announcement(ann, viewing_sk, spending_pk, spending_sk) {
-                ScanResult::Discovered(keys) => Some((idx, keys)),
+        .filter_map(
+            |(idx, ann)| match scan_announcement(ann, viewing_sk, spending_pub) {
+                ScanResult::Discovered(p) => Some((idx, p)),
                 _ => None,
-            }
-        })
+            },
+        )
         .collect()
 }
 
 /// Result of scanning announcements with additional context.
 #[derive(Debug)]
 pub struct DiscoveryResult {
-    /// The matching announcement.
+    /// The matching announcement (enriched with decrypted metadata).
     pub announcement: Announcement,
-    /// Derived stealth keys for the announcement.
-    pub keys: StealthKeys,
+    /// The discovered payment (address + shared secret).
+    pub payment: DiscoveredPayment,
     /// Index of the announcement in the input slice.
     pub index: usize,
 }
@@ -161,33 +221,21 @@ pub struct DiscoveryResult {
 pub fn scan_with_context(
     announcements: &[Announcement],
     viewing_sk: &[u8],
-    spending_pk: &[u8],
-    spending_sk: &[u8],
+    spending_pub: &[u8],
 ) -> Vec<DiscoveryResult> {
-    let (results, _stats) =
-        scan_with_context_and_stats(announcements, viewing_sk, spending_pk, spending_sk);
+    let (results, _stats) = scan_with_context_and_stats(announcements, viewing_sk, spending_pub);
     results
 }
 
 /// Scans announcements and returns both discoveries and accurate scan statistics.
 ///
-/// Unlike [`scan_with_context`], this distinguishes:
-/// - `total_scanned`: every announcement we attempted
-/// - `view_tag_matches`: announcements whose view tag matched after decap
-///   (the true filtering metric — strictly ≥ `discoveries`)
-/// - `discoveries`: subset of view-tag matches that produced valid stealth keys
-/// - `errors`: announcements that failed structural validation / decap / derive
-///
-/// Prefer this for any code path that surfaces scan statistics to the user
-/// (e.g. the REST API's `ScanStatsDto`).
+/// View-only: requires the viewing secret key and the spending *public* key.
 pub fn scan_with_context_and_stats(
     announcements: &[Announcement],
     viewing_sk: &[u8],
-    spending_pk: &[u8],
-    spending_sk: &[u8],
+    spending_pub: &[u8],
 ) -> (Vec<DiscoveryResult>, ScanStats) {
     use specter_core::types::KyberSecretKey;
-    use specter_crypto::derive::derive_stealth_keys;
 
     let mut stats = ScanStats::new();
     let mut results = Vec::new();
@@ -237,14 +285,14 @@ pub fn scan_with_context_and_stats(
         // reflects filter efficiency, not derivation success.
         stats.view_tag_matches += 1;
 
-        match derive_stealth_keys(spending_pk, spending_sk, &shared_secret) {
-            Ok(keys) => {
+        match build_discovered_payment(spending_pub, &shared_secret) {
+            Ok(payment) => {
                 stats.discoveries += 1;
                 // Repopulate payment fields by decrypting the on-chain
                 // metadata blob with the per-announcement shared secret.
-                // The secret never leaves this crate. Decryption failure
-                // (tampered/foreign blob) is silently ignored — the
-                // announcement is still returned, just without enrichment.
+                // Decryption failure (tampered/foreign blob) is silently
+                // ignored — the announcement is still returned, just without
+                // enrichment.
                 let mut enriched = ann.clone();
                 if let Some(blob) = &ann.metadata_blob {
                     if let Ok(pt) =
@@ -262,9 +310,10 @@ pub fn scan_with_context_and_stats(
                         }
                     }
                 }
+                enriched.stealth_address = Some(payment.address.to_checksum_string());
                 results.push(DiscoveryResult {
                     announcement: enriched,
-                    keys,
+                    payment,
                     index: idx,
                 });
             }
@@ -281,24 +330,35 @@ pub fn scan_with_context_and_stats(
 pub fn verify_address_from_announcement(
     announcement: &Announcement,
     viewing_sk: &[u8],
-    spending_pk: &[u8],
+    spending_pub: &[u8],
     expected_address: &EthAddress,
 ) -> Result<bool> {
     let ciphertext = KyberCiphertext::from_bytes(&announcement.ephemeral_key)?;
     let viewing_secret = specter_core::types::KyberSecretKey::from_bytes(viewing_sk)?;
     let shared_secret = decapsulate(&ciphertext, &viewing_secret)?;
-    let derived_address = derive_stealth_address(spending_pk, &shared_secret)?;
+    let derived_address = derive_stealth_address(spending_pub, &shared_secret)?;
     Ok(derived_address == *expected_address)
+}
+
+/// Convenience: for a discovered payment, derive the full spend keys using the
+/// recipient's secret spending key. This is the step that requires the secret.
+pub fn spend_keys_for(
+    payment: &DiscoveredPayment,
+    spending_pub: &[u8],
+    spending_sk: &[u8],
+) -> Result<StealthKeys> {
+    derive_spend_keys(spending_pub, spending_sk, &payment.shared_secret)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use specter_core::types::KyberPublicKey;
-    use specter_crypto::{encapsulate, generate_keypair};
+    use specter_crypto::{encapsulate, generate_keypair, generate_spending_keypair};
 
+    /// Returns `(spending_pub_bytes, spending_sk_bytes, viewing_pk_bytes, viewing_sk_bytes)`.
     fn create_test_keys() -> (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) {
-        let spending = generate_keypair();
+        let spending = generate_spending_keypair();
         let viewing = generate_keypair();
         (
             spending.public.as_bytes().to_vec(),
@@ -317,31 +377,46 @@ mod tests {
 
     #[test]
     fn test_scan_announcement_discovery() {
-        let (spending_pk, spending_sk, viewing_pk, viewing_sk) = create_test_keys();
+        let (spending_pub, _spending_sk, viewing_pk, viewing_sk) = create_test_keys();
         let announcement = create_announcement_for(&viewing_pk);
-        let result = scan_announcement(&announcement, &viewing_sk, &spending_pk, &spending_sk);
+        let result = scan_announcement(&announcement, &viewing_sk, &spending_pub);
         assert!(result.is_discovered());
-        let keys = result.into_keys().unwrap();
-        assert!(!keys.address.is_zero());
+        let p = result.into_payment().unwrap();
+        assert!(!p.address.is_zero());
     }
 
     #[test]
     fn test_scan_announcement_not_for_us() {
-        let (spending_pk, spending_sk, _viewing_pk, viewing_sk) = create_test_keys();
+        let (spending_pub, _spending_sk, _viewing_pk, viewing_sk) = create_test_keys();
         let other_viewing = generate_keypair();
         let announcement = create_announcement_for(other_viewing.public.as_bytes());
-        let result = scan_announcement(&announcement, &viewing_sk, &spending_pk, &spending_sk);
+        let result = scan_announcement(&announcement, &viewing_sk, &spending_pub);
         assert!(!result.is_discovered());
     }
 
-    /// `scan_with_context_and_stats` must report accurate filter efficiency,
-    /// not just discovery counts. A view-tag match that fails the (rare) derive
-    /// step still counts toward `view_tag_matches`.
+    /// A discovered payment's shared secret + spending secret must derive keys
+    /// whose address matches what the view-only scan reported.
+    #[test]
+    fn discovered_payment_derives_matching_spend_key() {
+        let (spending_pub, spending_sk, viewing_pk, viewing_sk) = create_test_keys();
+        let ann = create_announcement_for(&viewing_pk);
+        let payment = scan_announcement(&ann, &viewing_sk, &spending_pub)
+            .into_payment()
+            .unwrap();
+        let keys = spend_keys_for(&payment, &spending_pub, &spending_sk).unwrap();
+        assert_eq!(keys.address, payment.address);
+        // The eth private key controls that address.
+        let from_pk = specter_crypto::derive::derive_eth_address_from_seed(
+            &keys.private_key.to_eth_private_key(),
+        )
+        .unwrap();
+        assert_eq!(from_pk, payment.address);
+    }
+
     #[test]
     fn test_scan_stats_count_view_tag_matches_independently() {
-        let (spending_pk, spending_sk, viewing_pk, viewing_sk) = create_test_keys();
+        let (spending_pub, _spending_sk, viewing_pk, viewing_sk) = create_test_keys();
 
-        // 3 announcements addressed to us, 7 noise (different recipients).
         let mut anns = Vec::new();
         for _ in 0..3 {
             anns.push(create_announcement_for(&viewing_pk));
@@ -352,64 +427,53 @@ mod tests {
             ));
         }
 
-        let (results, stats) =
-            scan_with_context_and_stats(&anns, &viewing_sk, &spending_pk, &spending_sk);
+        let (results, stats) = scan_with_context_and_stats(&anns, &viewing_sk, &spending_pub);
 
         assert_eq!(stats.total_scanned, 10);
         assert_eq!(stats.discoveries, 3);
-        // view_tag_matches is at least our 3 — noise can cause false positives
-        // (1/256 per noise announcement) but every legitimate one must match.
         assert!(stats.view_tag_matches >= 3);
         assert_eq!(results.len(), 3);
         assert!(stats.view_tag_matches >= stats.discoveries);
     }
 
-    /// A garbage announcement that won't decapsulate is counted as an error,
-    /// never as a view-tag match or discovery.
     #[test]
     fn test_scan_stats_skip_invalid_announcements() {
-        let (spending_pk, spending_sk, _viewing_pk, viewing_sk) = create_test_keys();
+        let (spending_pub, _spending_sk, _viewing_pk, viewing_sk) = create_test_keys();
 
         let bad = Announcement::new(
             vec![0xFFu8; specter_core::constants::KYBER_CIPHERTEXT_SIZE],
             0,
         );
-        let (results, stats) =
-            scan_with_context_and_stats(&[bad], &viewing_sk, &spending_pk, &spending_sk);
+        let (results, stats) = scan_with_context_and_stats(&[bad], &viewing_sk, &spending_pub);
 
         assert_eq!(stats.total_scanned, 1);
         assert_eq!(stats.discoveries, 0);
-        // Decapsulation produces a pseudo-random shared secret, whose tag has
-        // a 1/256 chance of colliding with the announcement's. So
-        // view_tag_matches is either 0 (likely) or 1 (unlikely), but never >1.
         assert!(stats.view_tag_matches <= 1);
         assert!(results.is_empty());
     }
 
     #[test]
     fn test_scan_multiple_announcements() {
-        let (spending_pk, spending_sk, viewing_pk, viewing_sk) = create_test_keys();
+        let (spending_pub, _spending_sk, viewing_pk, viewing_sk) = create_test_keys();
         let ann1 = create_announcement_for(&viewing_pk);
         let ann2 = create_announcement_for(generate_keypair().public.as_bytes());
         let ann3 = create_announcement_for(&viewing_pk);
         let announcements = vec![ann1, ann2, ann3];
-        let discoveries =
-            scan_announcements(&announcements, &viewing_sk, &spending_pk, &spending_sk);
+        let discoveries = scan_announcements(&announcements, &viewing_sk, &spending_pub);
         assert_eq!(discoveries.len(), 2);
     }
 
     #[test]
     fn scan_empty_list_returns_empty() {
-        let (spending_pk, spending_sk, _vk, viewing_sk) = create_test_keys();
-        let discoveries = scan_announcements(&[], &viewing_sk, &spending_pk, &spending_sk);
+        let (spending_pub, _spending_sk, _vk, viewing_sk) = create_test_keys();
+        let discoveries = scan_announcements(&[], &viewing_sk, &spending_pub);
         assert!(discoveries.is_empty());
     }
 
     #[test]
     fn scan_with_context_and_stats_empty_list() {
-        let (spending_pk, spending_sk, _vk, viewing_sk) = create_test_keys();
-        let (results, stats) =
-            scan_with_context_and_stats(&[], &viewing_sk, &spending_pk, &spending_sk);
+        let (spending_pub, _spending_sk, _vk, viewing_sk) = create_test_keys();
+        let (results, stats) = scan_with_context_and_stats(&[], &viewing_sk, &spending_pub);
         assert!(results.is_empty());
         assert_eq!(stats.total_scanned, 0);
         assert_eq!(stats.discoveries, 0);
@@ -419,12 +483,11 @@ mod tests {
 
     #[test]
     fn scan_with_context_and_stats_invalid_viewing_sk() {
-        let (spending_pk, spending_sk, viewing_pk, _) = create_test_keys();
+        let (spending_pub, _spending_sk, viewing_pk, _) = create_test_keys();
         let ann = create_announcement_for(&viewing_pk);
         let bad_viewing_sk = vec![0u8; 16]; // wrong size
 
-        let (results, stats) =
-            scan_with_context_and_stats(&[ann], &bad_viewing_sk, &spending_pk, &spending_sk);
+        let (results, stats) = scan_with_context_and_stats(&[ann], &bad_viewing_sk, &spending_pub);
 
         assert!(results.is_empty());
         assert_eq!(stats.total_scanned, 1);
@@ -433,21 +496,20 @@ mod tests {
 
     #[test]
     fn scan_with_context_returns_same_count_as_scan_announcements() {
-        let (spending_pk, spending_sk, viewing_pk, viewing_sk) = create_test_keys();
+        let (spending_pub, _spending_sk, viewing_pk, viewing_sk) = create_test_keys();
         let mut anns = vec![
             create_announcement_for(&viewing_pk),
             create_announcement_for(generate_keypair().public.as_bytes()),
             create_announcement_for(&viewing_pk),
         ];
-        // add 5 more noise
         for _ in 0..5 {
             anns.push(create_announcement_for(
                 generate_keypair().public.as_bytes(),
             ));
         }
 
-        let flat = scan_announcements(&anns, &viewing_sk, &spending_pk, &spending_sk);
-        let ctx = scan_with_context(&anns, &viewing_sk, &spending_pk, &spending_sk);
+        let flat = scan_announcements(&anns, &viewing_sk, &spending_pub);
+        let ctx = scan_with_context(&anns, &viewing_sk, &spending_pub);
         assert_eq!(flat.len(), ctx.len());
         assert_eq!(flat.len(), 2);
     }
@@ -456,14 +518,14 @@ mod tests {
     fn scan_result_not_for_us_is_not_discovered() {
         let not_for_us = ScanResult::NotForUs;
         assert!(!not_for_us.is_discovered());
-        assert!(not_for_us.into_keys().is_none());
+        assert!(not_for_us.into_payment().is_none());
     }
 
     #[test]
     fn scan_stats_record_discovery_increments_all_counters() {
-        let (spending_pk, spending_sk, viewing_pk, viewing_sk) = create_test_keys();
+        let (spending_pub, _spending_sk, viewing_pk, viewing_sk) = create_test_keys();
         let ann = create_announcement_for(&viewing_pk);
-        let result = scan_announcement(&ann, &viewing_sk, &spending_pk, &spending_sk);
+        let result = scan_announcement(&ann, &viewing_sk, &spending_pub);
         assert!(result.is_discovered());
 
         let mut stats = ScanStats::new();
@@ -495,38 +557,6 @@ mod tests {
     }
 
     #[test]
-    fn scan_stats_rate_computed_correctly() {
-        let stats = ScanStats {
-            total_scanned: 1000,
-            duration_ms: 1000,
-            ..ScanStats::default()
-        };
-        // 1000 announcements in 1000ms = 1000/s
-        let rate = stats.rate();
-        assert!(
-            (rate - 1000.0).abs() < 0.01,
-            "expected ~1000.0, got {}",
-            rate
-        );
-    }
-
-    #[test]
-    fn scan_stats_filter_efficiency_zero_when_no_scans() {
-        let stats = ScanStats::default();
-        assert_eq!(stats.filter_efficiency(), 0.0);
-    }
-
-    #[test]
-    fn scan_stats_filter_efficiency_100_when_no_matches() {
-        let stats = ScanStats {
-            total_scanned: 100,
-            view_tag_matches: 0,
-            ..ScanStats::default()
-        };
-        assert!((stats.filter_efficiency() - 100.0).abs() < 0.01);
-    }
-
-    #[test]
     fn scan_stats_filter_efficiency_reflects_fraction() {
         let stats = ScanStats {
             total_scanned: 256,
@@ -539,73 +569,58 @@ mod tests {
 
     #[test]
     fn discovery_result_index_is_correct() {
-        let (spending_pk, spending_sk, viewing_pk, viewing_sk) = create_test_keys();
+        let (spending_pub, _spending_sk, viewing_pk, viewing_sk) = create_test_keys();
         let noise = create_announcement_for(generate_keypair().public.as_bytes());
         let ours = create_announcement_for(&viewing_pk);
         let anns = vec![noise, ours];
 
-        let ctx = scan_with_context(&anns, &viewing_sk, &spending_pk, &spending_sk);
+        let ctx = scan_with_context(&anns, &viewing_sk, &spending_pub);
         assert_eq!(ctx.len(), 1);
         assert_eq!(ctx[0].index, 1, "our announcement was at index 1");
     }
 
     #[test]
     fn verify_address_from_announcement_correct_key() {
-        let (spending_pk, _spending_sk, viewing_pk, viewing_sk) = create_test_keys();
+        let (spending_pub, _spending_sk, viewing_pk, viewing_sk) = create_test_keys();
         let ann = create_announcement_for(&viewing_pk);
 
         let ciphertext = specter_crypto::KyberCiphertext::from_bytes(&ann.ephemeral_key).unwrap();
         let vsk = specter_core::types::KyberSecretKey::from_bytes(&viewing_sk).unwrap();
         let shared_secret = specter_crypto::decapsulate(&ciphertext, &vsk).unwrap();
-        let expected_addr =
-            specter_crypto::derive::derive_stealth_address(&spending_pk, &shared_secret).unwrap();
+        let expected_addr = derive_stealth_address(&spending_pub, &shared_secret).unwrap();
 
-        let ok = verify_address_from_announcement(&ann, &viewing_sk, &spending_pk, &expected_addr)
-            .unwrap();
+        let ok =
+            verify_address_from_announcement(&ann, &viewing_sk, &spending_pub, &expected_addr)
+                .unwrap();
         assert!(ok, "correct key should verify address");
     }
 
     #[test]
     fn verify_address_from_announcement_wrong_address() {
-        let (spending_pk, _spending_sk, viewing_pk, viewing_sk) = create_test_keys();
+        let (spending_pub, _spending_sk, viewing_pk, viewing_sk) = create_test_keys();
         let ann = create_announcement_for(&viewing_pk);
 
-        let wrong_addr = specter_core::types::EthAddress::zero();
+        let wrong_addr = EthAddress::zero();
 
         let ok =
-            verify_address_from_announcement(&ann, &viewing_sk, &spending_pk, &wrong_addr).unwrap();
+            verify_address_from_announcement(&ann, &viewing_sk, &spending_pub, &wrong_addr).unwrap();
         assert!(!ok, "wrong address should not verify");
-    }
-
-    #[test]
-    fn scan_announcements_returns_correct_indices() {
-        let (spending_pk, spending_sk, viewing_pk, viewing_sk) = create_test_keys();
-        let noise1 = create_announcement_for(generate_keypair().public.as_bytes());
-        let ours = create_announcement_for(&viewing_pk);
-        let noise2 = create_announcement_for(generate_keypair().public.as_bytes());
-        let anns = vec![noise1, ours, noise2];
-
-        let discoveries = scan_announcements(&anns, &viewing_sk, &spending_pk, &spending_sk);
-        assert_eq!(discoveries.len(), 1);
-        assert_eq!(discoveries[0].0, 1, "ours is at index 1");
     }
 
     /// During scanning, the recipient must decrypt the on-chain `metadata_blob`
     /// using the per-announcement ML-KEM shared secret and repopulate the
-    /// payment fields (`payment_tx_hash`, `amount`, `source_chain_id`) that
-    /// Phase 1 moved into the AEAD-encrypted blob.
+    /// payment fields.
     #[test]
     fn scan_decrypts_metadata_blob_into_payment_fields() {
         use specter_core::types::AnnouncementMetadata;
         use specter_crypto::encrypt_announcement_metadata;
 
         let viewing = generate_keypair();
-        let spending = generate_keypair();
+        let spending = generate_spending_keypair();
         let pk = KyberPublicKey::from_bytes(viewing.public.as_bytes()).unwrap();
         let (ciphertext, shared_secret) = encapsulate(&pk).unwrap();
         let view_tag = compute_view_tag(&shared_secret);
 
-        // Build plaintext metadata, encrypt it under the shared secret.
         let tx = [0xAAu8; 32];
         let mut amount = [0u8; 32];
         amount[31] = 1; // 1 wei
@@ -614,7 +629,6 @@ mod tests {
             .with_amount(amount)
             .with_source_chain_id(42161)
             .encode();
-        // shared_secret is already [u8; 32]; pass it directly.
         let blob = encrypt_announcement_metadata(&plaintext, &shared_secret).to_vec();
 
         let mut ann = Announcement::new(ciphertext.into_bytes(), view_tag);
@@ -624,7 +638,6 @@ mod tests {
             &[ann],
             viewing.secret.as_bytes(),
             spending.public.as_bytes(),
-            spending.secret.as_bytes(),
         );
 
         assert_eq!(results.len(), 1);

--- a/specter/specter-stealth/src/payment.rs
+++ b/specter/specter-stealth/src/payment.rs
@@ -45,9 +45,9 @@ pub fn create_stealth_payment(meta_address: &MetaAddress) -> Result<StealthPayme
     let (ciphertext, shared_secret) = encapsulate(&meta_address.viewing_pk)?;
     let view_tag = compute_view_tag(&shared_secret);
     let stealth_address =
-        derive_stealth_address(meta_address.spending_pk.as_bytes(), &shared_secret)?;
+        derive_stealth_address(meta_address.spending_pub.as_bytes(), &shared_secret)?;
     let stealth_sui_address =
-        derive_stealth_sui_address(meta_address.spending_pk.as_bytes(), &shared_secret)?;
+        derive_stealth_sui_address(meta_address.spending_pub.as_bytes(), &shared_secret)?;
     let announcement = Announcement::new(ciphertext.into_bytes(), view_tag);
 
     Ok(StealthPayment {
@@ -133,9 +133,9 @@ impl StealthPaymentBuilder {
         let (ciphertext, shared_secret) = encapsulate(&meta_address.viewing_pk)?;
         let view_tag = compute_view_tag(&shared_secret);
         let stealth_address =
-            derive_stealth_address(meta_address.spending_pk.as_bytes(), &shared_secret)?;
+            derive_stealth_address(meta_address.spending_pub.as_bytes(), &shared_secret)?;
         let stealth_sui_address =
-            derive_stealth_sui_address(meta_address.spending_pk.as_bytes(), &shared_secret)?;
+            derive_stealth_sui_address(meta_address.spending_pub.as_bytes(), &shared_secret)?;
         let mut announcement = Announcement::new(ciphertext.into_bytes(), view_tag);
         if let Some(chain_id) = self.source_chain_id {
             announcement.source_chain_id = Some(chain_id);
@@ -172,10 +172,10 @@ pub fn verify_payment(payment: &StealthPayment, _meta_address: &MetaAddress) -> 
 mod tests {
     use super::*;
     use specter_crypto::derive::{derive_eth_address_from_seed, derive_stealth_keys};
-    use specter_crypto::{decapsulate, generate_keypair, KyberCiphertext};
+    use specter_crypto::{decapsulate, generate_keypair, generate_spending_keypair, KyberCiphertext};
 
     fn create_test_meta_address() -> MetaAddress {
-        let spending = generate_keypair();
+        let spending = generate_spending_keypair();
         let viewing = generate_keypair();
         MetaAddress::new(spending.public.clone(), viewing.public.clone())
     }
@@ -273,7 +273,7 @@ mod tests {
     /// Proves stealth_address matches the address derived from eth_private_key (wallet compatibility).
     #[test]
     fn test_stealth_address_matches_eth_private_key() {
-        let spending = generate_keypair();
+        let spending = generate_spending_keypair();
         let viewing = generate_keypair();
         let meta = MetaAddress::new(spending.public.clone(), viewing.public.clone());
 

--- a/specter/specter-stealth/src/wallet.rs
+++ b/specter/specter-stealth/src/wallet.rs
@@ -7,9 +7,9 @@ use serde::{Deserialize, Serialize};
 use zeroize::ZeroizeOnDrop;
 
 use specter_core::error::Result;
-use specter_core::types::{KyberPublicKey, MetaAddress, SpecterKeys};
+use specter_core::types::{KyberPublicKey, MetaAddress, Secp256k1PublicKey, SpecterKeys};
 use specter_crypto::derive::{derive_stealth_keys, StealthKeys};
-use specter_crypto::{compute_view_tag, decapsulate, generate_keypair};
+use specter_crypto::{compute_view_tag, decapsulate, generate_keypair, generate_spending_keypair};
 
 /// Configuration for wallet creation.
 #[derive(Clone, Debug, Default)]
@@ -54,8 +54,8 @@ impl SpecterWallet {
 
     /// Generates a new wallet with custom configuration.
     pub fn generate_with_config(config: WalletConfig) -> Result<Self> {
-        // Generate spending and viewing key pairs
-        let spending = generate_keypair();
+        // Generate spending (secp256k1) and viewing (ML-KEM) key pairs
+        let spending = generate_spending_keypair();
         let viewing = generate_keypair();
 
         let meta_address = MetaAddress::new(spending.public.clone(), viewing.public.clone());
@@ -92,8 +92,8 @@ impl SpecterWallet {
         &self.meta_address
     }
 
-    /// Returns the spending public key.
-    pub fn spending_public_key(&self) -> &KyberPublicKey {
+    /// Returns the secp256k1 spending public key.
+    pub fn spending_public_key(&self) -> &Secp256k1PublicKey {
         &self.keys.spending.public
     }
 


### PR DESCRIPTION

Fixes the critical flaw where the sender could derive a stealth address's private key (v1 derived it as a pure hash of shared_secret + the *public* spending key). v2 uses an ERC-5564-style secp256k1 additive tweak so only the holder of the secret spending scalar can spend.

- core: new Secp256k1{PublicKey,SecretKey,KeyPair}; MetaAddress.spending_pk ->
  spending_pub (secp256k1); wire v2 = version(2) || spending_pub(33) ||
  viewing_pk(1184); PROTOCOL_VERSION=2, v1 rejected. viewing stays ML-KEM-768.
- crypto/derive: t = H_to_scalar("SPECTER_STEALTH_TWEAK_V2" || shared_secret); address P = B + t*G (sender, public-only); spend key p = b + t mod n (recipient, needs secret). generate_spending_keypair(); removed legacy XOR / derive_eth_key_seed paths. Adds sender_cannot_derive_stealth_private_key test.
- stealth/scanner/api: scanning is now view-only (viewing_sk + spending_pub); DiscoveredPayment carries shared_secret; spend keys via derive_spend_keys. /stealth/scan drops spending_sk and returns shared_secret; /keys/generate returns spending_pub + protocol_version.
- cli, e2e-flow, benches updated.

BREAKING: v1 keys, meta-addresses and stealth payments are invalid; regenerate keys and re-publish ENS/SuiNS. Treat v1 stealth addresses as compromised.